### PR TITLE
moved `pepper` to a setuptools entry_point

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 A CLI interface to a remote salt-api instance
 
@@ -19,7 +18,7 @@ import pepper
 
 try:
     from logging import NullHandler
-except ImportError: # Python < 2.7
+except ImportError:  # Python < 2.7
     class NullHandler(logging.Handler):
         def emit(self, record): pass
 
@@ -199,11 +198,11 @@ def get_login_details(opts):
 
     return results
 
-def main():
+def pepper_main():
     '''
     '''
     global interactive_check
-    if hasattr(main, '__file__'):
+    if hasattr(pepper_main, '__file__'):
       interactive_check = False
     else:
       interactive_check = True
@@ -263,9 +262,9 @@ def main():
 
     return (exit_code,json.dumps(commandRet['return'][0], sort_keys=True, indent=4))
 
-if __name__ == '__main__':
+def pepper_cli():
     try:
-        exit_code, results = main()
+        exit_code, results = pepper_main()
         # TODO: temporary printing until Salt outputters are in place
         print(results)
         raise SystemExit(exit_code)

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -261,21 +261,3 @@ def pepper_main():
          exit_code = 0
 
     return (exit_code,json.dumps(commandRet['return'][0], sort_keys=True, indent=4))
-
-def pepper_cli():
-    try:
-        exit_code, results = pepper_main()
-        # TODO: temporary printing until Salt outputters are in place
-        print(results)
-        raise SystemExit(exit_code)
-    except pepper.PepperException as exc:
-        print('Pepper error: {0}'.format(exc), file=sys.stderr)
-        raise SystemExit(1)
-    except KeyboardInterrupt:
-        # TODO: mimic CLI and output JID on ctrl-c
-        raise SystemExit(0)
-    except Exception:
-        print('Uncaught Pepper error (increase verbosity for the full traceback).',
-                file=sys.stderr)
-        logger.debug('Uncaught traceback:', exc_info=True)
-        raise SystemExit(1)

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -26,238 +26,242 @@ logging.basicConfig(format='%(levelname)s %(asctime)s %(module)s: %(message)s')
 logger = logging.getLogger('pepper')
 logger.addHandler(NullHandler())
 
-default_timeout_in_seconds = 60 * 60
-seconds_to_wait = 3
 
-def get_parser():
-    parser = optparse.OptionParser(
-        description=__doc__,
-        usage='%prog [opts]',
-        version=pepper.__version__)
+class PepperCli(object):
+    def __init__(self, default_timeout_in_seconds=60*60, seconds_to_wait=3):
+        self.seconds_to_wait = seconds_to_wait
+        self.parser = self.get_parser()
+        self.parser.option_groups.extend([self.add_globalopts(),
+                                          self.add_tgtopts(),
+                                          self.add_authopts()])
+        self.parser.defaults.update({'timeout': default_timeout_in_seconds,
+                                     'fail_if_minions_dont_respond': False,
+                                     'expr_form': 'glob'})
 
-    parser.add_option('-c', dest='config',
-        default=os.environ.get('PEPPERRC',
-            os.path.join(os.path.expanduser('~'), '.pepperrc')),
-        help=textwrap.dedent('''\
-            Configuration file location. Default is a file path in the
-            "PEPPERRC" environment variable or ~/.pepperrc.'''))
+    def get_parser(self):
+        return optparse.OptionParser(
+            description=__doc__,
+            usage='%prog [opts]',
+            version=pepper.__version__)
 
-    parser.add_option('-v', dest='verbose', default=0, action='count',
-        help=textwrap.dedent('''\
-            Increment output verbosity; may be specified multiple times'''))
+    def parse(self):
+        '''
+        Parse all args
+        '''
+        self.parser.add_option('-c', dest='config',
+            default=os.environ.get('PEPPERRC',
+                os.path.join(os.path.expanduser('~'), '.pepperrc')),
+            help=textwrap.dedent('''\
+                Configuration file location. Default is a file path in the
+                "PEPPERRC" environment variable or ~/.pepperrc.'''))
 
-    parser.add_option('-H', '--debug-http', dest='debug_http', default=False,
-        action='store_true', help=textwrap.dedent('''\
-        Output the HTTP request/response headers on stderr'''))
+        self.parser.add_option('-v', dest='verbose', default=0, action='count',
+            help=textwrap.dedent('''\
+                Increment output verbosity; may be specified multiple times'''))
 
-    return parser
+        self.parser.add_option('-H', '--debug-http', dest='debug_http', default=False,
+            action='store_true', help=textwrap.dedent('''\
+            Output the HTTP request/response headers on stderr'''))
 
-def add_globalopts(parser):
-    '''
-    Misc global options
-    '''
-    optgroup = optparse.OptionGroup(parser, "Pepper ``salt`` Options",
-            "Mimic the ``salt`` CLI")
+        self.options, self.args = self.parser.parse_args()
 
-    optgroup.add_option('-t', '--timeout', dest='timeout', type ='int',
-        help="Specify wait time (in seconds) before returning control to the shell")
+    def add_globalopts(self):
+        '''
+        Misc global options
+        '''
+        optgroup = optparse.OptionGroup(self.parser, "Pepper ``salt`` Options",
+                "Mimic the ``salt`` CLI")
 
-    #optgroup.add_option('--out', '--output', dest='output',
-    #        help="Specify the output format for the command output")
+        optgroup.add_option('-t', '--timeout', dest='timeout', type ='int',
+            help="Specify wait time (in seconds) before returning control to the shell")
 
-    #optgroup.add_option('--return', default='', metavar='RETURNER',
-    #    help="Redirect the output from a command to a persistent data store")
+        #optgroup.add_option('--out', '--output', dest='output',
+        #        help="Specify the output format for the command output")
 
-    optgroup.add_option('--fail-if-incomplete', action='store_true',
-        dest='fail_if_minions_dont_respond',
-        help="Optional, return a failure exit code if not all minions respond")
+        #optgroup.add_option('--return', default='', metavar='RETURNER',
+        #    help="Redirect the output from a command to a persistent data store")
 
-    parser.set_defaults(timeout=default_timeout_in_seconds)
-    parser.set_defaults(fail_if_minions_dont_respond=False)
-    parser.add_option_group(optgroup)
+        optgroup.add_option('--fail-if-incomplete', action='store_true',
+            dest='fail_if_minions_dont_respond',
+            help="Optional, return a failure exit code if not all minions respond")
 
-def add_tgtopts(parser):
-    '''
-    Targeting
-    '''
-    optgroup = optparse.OptionGroup(parser, "Targeting Options",
-            "Target which minions to run commands on")
+        return optgroup
 
-    optgroup.add_option('-E', '--pcre', dest='expr_form',
-            action='store_const', const='pcre',
-        help="Target hostnames using PCRE regular expressions")
+    def add_tgtopts(self):
+        '''
+        Targeting
+        '''
+        optgroup = optparse.OptionGroup(self.parser, "Targeting Options",
+                "Target which minions to run commands on")
 
-    optgroup.add_option('-L', '--list', dest='expr_form',
-            action='store_const', const='list',
-        help="Specify a comma delimited list of hostnames")
+        optgroup.add_option('-E', '--pcre', dest='expr_form',
+                action='store_const', const='pcre',
+            help="Target hostnames using PCRE regular expressions")
 
-    optgroup.add_option('-G', '--grain', dest='expr_form',
-            action='store_const', const='grain',
-        help="Target based on system properties")
+        optgroup.add_option('-L', '--list', dest='expr_form',
+                action='store_const', const='list',
+            help="Specify a comma delimited list of hostnames")
 
-    optgroup.add_option('--grain-pcre', dest='expr_form',
-            action='store_const', const='grain_pcre',
-        help="Target based on PCRE matches on system properties")
+        optgroup.add_option('-G', '--grain', dest='expr_form',
+                action='store_const', const='grain',
+            help="Target based on system properties")
 
-    parser.set_defaults(expr_form='glob')
-    parser.add_option_group(optgroup)
+        optgroup.add_option('--grain-pcre', dest='expr_form',
+                action='store_const', const='grain_pcre',
+            help="Target based on PCRE matches on system properties")
 
-def add_authopts(parser):
-    '''
-    Authentication options
-    '''
-    optgroup = optparse.OptionGroup(parser, "Authentication Options",
-            textwrap.dedent("""\
-            Authentication credentials can optionally be supplied via the
-            environment variables:
-            SALTAPI_URL, SALTAPI_USER, SALTAPI_PASS, SALTAPI_EAUTH.
-            """))
+        return optgroup
 
-    optgroup.add_option('--saltapi-url', dest='saltapiurl', default='https://localhost:8000/',
-            help="Specify the host url.  Defaults to https://localhost:8080")
+    def add_authopts(self):
+        '''
+        Authentication options
+        '''
+        optgroup = optparse.OptionGroup(self.parser, "Authentication Options",
+                textwrap.dedent("""\
+                Authentication credentials can optionally be supplied via the
+                environment variables:
+                SALTAPI_URL, SALTAPI_USER, SALTAPI_PASS, SALTAPI_EAUTH.
+                """))
 
-    optgroup.add_option('-a', '--auth', '--eauth', '--extended-auth',
-        dest='eauth', help=textwrap.dedent("""\
-                Specify the external_auth backend to authenticate against and
-                interactively prompt for credentials"""))
+        optgroup.add_option('--saltapi-url', dest='saltapiurl', default='https://localhost:8000/',
+                help="Specify the host url.  Defaults to https://localhost:8080")
 
-    optgroup.add_option('--username',
-        dest='username', help=textwrap.dedent("""\
-                Optional, defaults to user name. will be prompt if empty unless --non-interactive"""))
+        optgroup.add_option('-a', '--auth', '--eauth', '--extended-auth',
+            dest='eauth', help=textwrap.dedent("""\
+                    Specify the external_auth backend to authenticate against and
+                    interactively prompt for credentials"""))
 
-    optgroup.add_option('--password',
-        dest='password', help=textwrap.dedent("""\
-                Optional, but will be prompted unless --non-interactive"""))
+        optgroup.add_option('--username',
+            dest='username', help=textwrap.dedent("""\
+                    Optional, defaults to user name. will be prompt if empty unless --non-interactive"""))
 
-    optgroup.add_option('--non-interactive',
-        action='store_false', dest='interactive', help=textwrap.dedent("""\
-                Optional, fail rather than waiting for input"""),default=interactive_check)
+        optgroup.add_option('--password',
+            dest='password', help=textwrap.dedent("""\
+                    Optional, but will be prompted unless --non-interactive"""))
 
-    # optgroup.add_option('-T', '--make-token', default=False,
-    #     dest='mktoken', action='store_true',
-    #     help=textwrap.dedent("""\
-    #         Generate and save an authentication token for re-use. The token is
-    #         generated and made available for the period defined in the Salt
-    #         Master."""))
+        optgroup.add_option('--non-interactive',
+            action='store_false', dest='interactive', help=textwrap.dedent("""\
+                    Optional, fail rather than waiting for input"""),default=True)
 
-    parser.add_option_group(optgroup)
+        # optgroup.add_option('-T', '--make-token', default=False,
+        #     dest='mktoken', action='store_true',
+        #     help=textwrap.dedent("""\
+        #         Generate and save an authentication token for re-use. The token is
+        #         generated and made available for the period defined in the Salt
+        #         Master."""))
 
-def get_login_details(opts):
-    '''
-    This parses the config file, environment variables and command line options
-    and returns the config values
-    Order of parsing:
-        command line options, ~/.pepperrc, environment, defaults
-    '''
+        return optgroup
 
-    # setting default values
-    results = {
-        'SALTAPI_URL': 'https://localhost:8000/',
-        'SALTAPI_USER': 'saltdev',
-        'SALTAPI_PASS': 'saltdev',
-        'SALTAPI_EAUTH': 'auto',
-    }
+    def get_login_details(self):
+        '''
+        This parses the config file, environment variables and command line options
+        and returns the config values
+        Order of parsing:
+            command line options, ~/.pepperrc, environment, defaults
+        '''
 
-    profile = 'main'
+        # setting default values
+        results = {
+            'SALTAPI_URL': 'https://localhost:8000/',
+            'SALTAPI_USER': 'saltdev',
+            'SALTAPI_PASS': 'saltdev',
+            'SALTAPI_EAUTH': 'auto',
+        }
 
-    config = ConfigParser.RawConfigParser()
-    config.read(opts.config)
+        config = ConfigParser.RawConfigParser()
+        config.read(self.options.config)
 
-    # read file
-    if config.has_section(profile):
-        for key, value in config.items(profile):
-            key = key.upper()
-            results[key] = config.get(profile, key)
+        # read file
+        profile = 'main'
+        if config.has_section(profile):
+            for key, value in config.items(profile):
+                key = key.upper()
+                results[key] = config.get(profile, key)
 
-    # get environment values
-    for key, value in results.items():
-        results[key] = os.environ.get(key, results[key])
+        # get environment values
+        for key, value in results.items():
+            results[key] = os.environ.get(key, results[key])
 
-    # get eauth prompt options
-    if opts.saltapiurl:
-        results['SALTAPI_URL'] = opts.saltapiurl
+        # get eauth prompt options
+        if self.options.saltapiurl:
+            results['SALTAPI_URL'] = self.options.saltapiurl
 
-    if opts.eauth:
-        results['SALTAPI_EAUTH'] = opts.eauth
-        if opts.username == None:
-          if opts.interactive:
-            results['SALTAPI_USER'] = raw_input('Username: ')
-          else:
-            logger.error("SALTAPI_USER required")
-            raise SystemExit(1)
+        if self.options.eauth:
+            results['SALTAPI_EAUTH'] = self.options.eauth
+            if self.options.username == None:
+                if self.options.interactive:
+                    results['SALTAPI_USER'] = raw_input('Username: ')
+                else:
+                    logger.error("SALTAPI_USER required")
+                    raise SystemExit(1)
+            else:
+                results['SALTAPI_USER'] = self.options.username
+            if self.options.password == None:
+                if self.options.interactive:
+                    results['SALTAPI_PASS'] = getpass.getpass(prompt='Password: ')
+                else:
+                    logger.error("SALTAPI_PASS required")
+                    raise SystemExit(1)
+            else:
+                results['SALTAPI_PASS'] = self.options.password
+
+        return results
+
+    def run(self):
+        '''
+        Parse all arguments and call salt-api
+        '''
+        self.parse()
+
+        # move logger instantiation to method?
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(max(logging.ERROR - (self.options.verbose * 10), 1))
+
+        if len(self.args) < 2:
+            self.parser.error("Command not specified")
+
+        tgt, fun = self.args[0:2]
+
+        login_details = self.get_login_details()
+
+        # Auth values placeholder; grab interactively at CLI or from config file
+        salturl = login_details['SALTAPI_URL']
+        saltuser = login_details['SALTAPI_USER']
+        saltpass = login_details['SALTAPI_PASS']
+        salteauth = login_details['SALTAPI_EAUTH']
+
+        api = pepper.Pepper(salturl, debug_http=self.options.debug_http)
+        auth = api.login(saltuser, saltpass, salteauth)
+        nodesJidRet = api.local_async(tgt=tgt, fun='test.ping', expr_form=self.options.expr_form)
+        nodesJid = nodesJidRet['return'][0]['jid']
+        time.sleep(seconds_to_wait)
+        nodesRet = api.lookup_jid(nodesJid)
+
+        if fun == 'test.ping':
+            return (0,json.dumps(nodesRet['return'][0], sort_keys=True, indent=4))
+
+        nodes = nodesRet['return'][0].keys()
+        if nodes == []:
+            return (0,json.dumps({}))
+
+        commandJidRet = api.local_async(tgt=nodes, fun=fun, arg=args[2:], expr_form='list')
+        commandJid = commandJidRet['return'][0]['jid']
+        # keep trying until all expected nodes return
+        commandRet = api.lookup_jid(commandJid)
+        returnedNodes = commandRet['return'][0].keys()
+        total_time = seconds_to_wait
+
+        while set(returnedNodes) != set(nodes):
+            if total_time > self.options.timeout :
+                break
+
+            time.sleep(seconds_to_wait)
+            commandRet = api.lookup_jid(commandJid)
+            returnedNodes = commandRet['return'][0].keys()
+
+        if set(returnedNodes) != set(nodes) and self.options.fail_if_minions_dont_respond is True:
+            exit_code = 1
         else:
-          results['SALTAPI_USER'] = opts.username
-        if opts.password == None:
-          if opts.interactive:
-            results['SALTAPI_PASS'] = getpass.getpass(prompt='Password: ')
-          else:
-            logger.error("SALTAPI_PASS required")
-            raise SystemExit(1)
-        else:
-          results['SALTAPI_PASS'] = opts.password
+            exit_code = 0
 
-    return results
-
-def pepper_main():
-    '''
-    '''
-    global interactive_check
-    if hasattr(pepper_main, '__file__'):
-      interactive_check = False
-    else:
-      interactive_check = True
-
-    parser = get_parser()
-
-    add_globalopts(parser)
-    add_tgtopts(parser)
-    add_authopts(parser)
-
-    opts, args = parser.parse_args()
-
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(max(logging.ERROR - (opts.verbose * 10), 1))
-
-    if len(args) < 2:
-        parser.error("Command not recognized.")
-
-    tgt, fun = args.pop(0), args.pop(0)
-
-    login_details = get_login_details(opts)
-
-    # Auth values placeholder; grab interactively at CLI or from config file
-    salturl = login_details['SALTAPI_URL']
-    saltuser = login_details['SALTAPI_USER']
-    saltpass = login_details['SALTAPI_PASS']
-    salteauth = login_details['SALTAPI_EAUTH']
-
-    api = pepper.Pepper(salturl, debug_http=opts.debug_http)
-    auth = api.login(saltuser, saltpass, salteauth)
-    nodesJidRet = api.local_async(tgt=tgt, fun='test.ping', expr_form=opts.expr_form)
-    nodesJid = nodesJidRet['return'][0]['jid']
-    time.sleep(seconds_to_wait)
-    nodesRet = api.lookup_jid(nodesJid)
-    if fun == 'test.ping':
-        return (0,json.dumps(nodesRet['return'][0], sort_keys=True, indent=4))
-    nodes = nodesRet['return'][0].keys()
-    if nodes == []:
-        return (0,json.dumps({}))
-    commandJidRet = api.local_async(tgt=nodes, fun=fun, arg=args, expr_form='list')
-    commandJid = commandJidRet['return'][0]['jid']
-    # keep trying until all expected nodes return
-    commandRet = api.lookup_jid(commandJid)
-    returnedNodes = commandRet['return'][0].keys()
-    total_time = seconds_to_wait
-    while set(returnedNodes) != set(nodes):
-      if total_time > opts.timeout :
-         break
-      time.sleep(seconds_to_wait)
-      commandRet = api.lookup_jid(commandJid)
-      returnedNodes = commandRet['return'][0].keys()
-
-    if set(returnedNodes) != set(nodes) and opts.fail_if_minions_dont_respond is True:
-         exit_code = 1
-    else:
-         exit_code = 0
-
-    return (exit_code,json.dumps(commandRet['return'][0], sort_keys=True, indent=4))
+        return (exit_code,json.dumps(commandRet['return'][0], sort_keys=True, indent=4))

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -8,7 +8,6 @@ import json
 import logging
 import optparse
 import os
-import sys
 import textwrap
 import ConfigParser
 import getpass
@@ -75,10 +74,10 @@ class PepperCli(object):
         optgroup.add_option('-t', '--timeout', dest='timeout', type ='int',
             help="Specify wait time (in seconds) before returning control to the shell")
 
-        #optgroup.add_option('--out', '--output', dest='output',
+        # optgroup.add_option('--out', '--output', dest='output',
         #        help="Specify the output format for the command output")
 
-        #optgroup.add_option('--return', default='', metavar='RETURNER',
+        # optgroup.add_option('--return', default='', metavar='RETURNER',
         #    help="Redirect the output from a command to a persistent data store")
 
         optgroup.add_option('--fail-if-incomplete', action='store_true',
@@ -123,7 +122,7 @@ class PepperCli(object):
                 SALTAPI_URL, SALTAPI_USER, SALTAPI_PASS, SALTAPI_EAUTH.
                 """))
 
-        optgroup.add_option('--saltapi-url', dest='saltapiurl', default='https://localhost:8000/',
+        optgroup.add_option('-u', '--saltapi-url', dest='saltapiurl', default='https://localhost:8000/',
                 help="Specify the host url.  Defaults to https://localhost:8080")
 
         optgroup.add_option('-a', '--auth', '--eauth', '--extended-auth',
@@ -141,7 +140,7 @@ class PepperCli(object):
 
         optgroup.add_option('--non-interactive',
             action='store_false', dest='interactive', help=textwrap.dedent("""\
-                    Optional, fail rather than waiting for input"""),default=True)
+                    Optional, fail rather than waiting for input"""), default=True)
 
         # optgroup.add_option('-T', '--make-token', default=False,
         #     dest='mktoken', action='store_true',
@@ -188,7 +187,7 @@ class PepperCli(object):
 
         if self.options.eauth:
             results['SALTAPI_EAUTH'] = self.options.eauth
-            if self.options.username == None:
+            if self.options.username is None:
                 if self.options.interactive:
                     results['SALTAPI_USER'] = raw_input('Username: ')
                 else:
@@ -196,7 +195,7 @@ class PepperCli(object):
                     raise SystemExit(1)
             else:
                 results['SALTAPI_USER'] = self.options.username
-            if self.options.password == None:
+            if self.options.password is None:
                 if self.options.interactive:
                     results['SALTAPI_PASS'] = getpass.getpass(prompt='Password: ')
                 else:
@@ -234,7 +233,7 @@ class PepperCli(object):
         auth = api.login(saltuser, saltpass, salteauth)
         nodesJidRet = api.local_async(tgt=tgt, fun='test.ping', expr_form=self.options.expr_form)
         nodesJid = nodesJidRet['return'][0]['jid']
-        time.sleep(seconds_to_wait)
+        time.sleep(self.seconds_to_wait)
         nodesRet = api.lookup_jid(nodesJid)
 
         if fun == 'test.ping':
@@ -249,13 +248,13 @@ class PepperCli(object):
         # keep trying until all expected nodes return
         commandRet = api.lookup_jid(commandJid)
         returnedNodes = commandRet['return'][0].keys()
-        total_time = seconds_to_wait
+        total_time = self.seconds_to_wait
 
         while set(returnedNodes) != set(nodes):
             if total_time > self.options.timeout :
                 break
 
-            time.sleep(seconds_to_wait)
+            time.sleep(self.seconds_to_wait)
             commandRet = api.lookup_jid(commandJid)
             returnedNodes = commandRet['return'][0].keys()
 

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+'''
+A CLI interface to a remote salt-api instance
+'''
+from __future__ import print_function
+
+import sys
+import logging
+
+from pepper.cli import pepper_main
+from pepper import PepperException
+
+try:
+    from logging import NullHandler
+except ImportError: # Python < 2.7
+    class NullHandler(logging.Handler):
+        def emit(self, record): pass
+
+logging.basicConfig(format='%(levelname)s %(asctime)s %(module)s: %(message)s')
+logger = logging.getLogger('pepper')
+logger.addHandler(NullHandler())
+
+if __name__ == '__main__':
+    try:
+        exit_code, results = pepper_main()
+        # TODO: temporary printing until Salt outputters are in place
+        print(results)
+        raise SystemExit(exit_code)
+    except PepperException as exc:
+        print('Pepper error: {0}'.format(exc), file=sys.stderr)
+        raise SystemExit(1)
+    except KeyboardInterrupt:
+        # TODO: mimic CLI and output JID on ctrl-c
+        raise SystemExit(0)
+    except Exception as e:
+        print(e)
+        print('Uncaught Pepper error (increase verbosity for the full traceback).',
+                file=sys.stderr)
+        logger.debug('Uncaught traceback:', exc_info=True)
+        raise SystemExit(1)

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -7,7 +7,7 @@ from __future__ import print_function
 import sys
 import logging
 
-from pepper.cli import pepper_main
+from pepper.cli import PepperCli
 from pepper import PepperException
 
 try:
@@ -22,7 +22,8 @@ logger.addHandler(NullHandler())
 
 if __name__ == '__main__':
     try:
-        exit_code, results = pepper_main()
+        cli = PepperCli()
+        exit_code, results = cli.run()
         # TODO: temporary printing until Salt outputters are in place
         print(results)
         raise SystemExit(exit_code)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ A CLI front-end to a running salt-api system
 import json
 import os
 
-from distutils.core import setup
+from setuptools import setup
 from distutils.command import sdist, install_data
 
 setup_kwargs = {
@@ -36,9 +36,11 @@ setup_kwargs = {
     'package_data': {
         'pepper': ['version.json'],
     },
-    'scripts': [
-        'scripts/pepper'
-    ],
+    'entry_points': {
+        'console_scripts': [
+            'pepper = pepper.cli:pepper_cli'
+        ]
+    }
 }
 
 def read_version_tag():

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ A CLI front-end to a running salt-api system
 import json
 import os
 
-from setuptools import setup
+from distutils.core import setup
+from distutils.dist import Distribution
 from distutils.command import sdist, install_data
 
 setup_kwargs = {
@@ -36,11 +37,9 @@ setup_kwargs = {
     'package_data': {
         'pepper': ['version.json'],
     },
-    'entry_points': {
-        'console_scripts': [
-            'pepper = pepper.cli:pepper_cli'
-        ]
-    }
+    'scripts': [
+        'scripts/pepper',
+    ]
 }
 
 def read_version_tag():


### PR DESCRIPTION
Hiya!

Just to bring pepper inline with the rest of salt, I wanted to move the command line invocation out of a script and into a module of the library as an entry_point. This will allow people to wrap the command line interface in their own python projects.

I realize that salstack/salt does some customization with the distclass to get entry points, and it seems to prefer using distutils, but I swapped it for setuptools here because you get entry_points for free. Not sure if that will be a problem or not :/

tested functionality with my fork before submitting the PR, everything works identically to before. 

thanks for looking!