### PR TITLE
fixes SALTAPI_URL precedence

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -122,7 +122,7 @@ class PepperCli(object):
                 SALTAPI_URL, SALTAPI_USER, SALTAPI_PASS, SALTAPI_EAUTH.
                 """))
 
-        optgroup.add_option('-u', '--saltapi-url', dest='saltapiurl', default='https://localhost:8000/',
+        optgroup.add_option('-u', '--saltapi-url', dest='saltapiurl',
                 help="Specify the host url.  Defaults to https://localhost:8080")
 
         optgroup.add_option('-a', '--auth', '--eauth', '--extended-auth',


### PR DESCRIPTION
Weird bug.

Because the --saltapi-url option had a default "localhost:8000" it would always return a string & thus evaluate `True` in the `get_login_details` method/function:

        # get eauth prompt options
        if self.options.saltapiurl:
            results['SALTAPI_URL'] = self.options.saltapiurl

removing the default at the option level actually fixes the precedence, since the same default is set in `get_login_details` here:

        # setting default values
        results = {
            'SALTAPI_URL': 'https://localhost:8000/',
            'SALTAPI_USER': 'saltdev',
            'SALTAPI_PASS': 'saltdev',
            'SALTAPI_EAUTH': 'auto',
        }

thanks for looking!