### PR TITLE
forgot 'self'

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -243,7 +243,7 @@ class PepperCli(object):
         if nodes == []:
             return (0,json.dumps({}))
 
-        commandJidRet = api.local_async(tgt=nodes, fun=fun, arg=args[2:], expr_form='list')
+        commandJidRet = api.local_async(tgt=nodes, fun=fun, arg=self.args[2:], expr_form='list')
         commandJid = commandJidRet['return'][0]['jid']
         # keep trying until all expected nodes return
         commandRet = api.lookup_jid(commandJid)


### PR DESCRIPTION
hopefully this is the last single line bugfix PR for the foreseeable future.

this fixes the following error:

    (v)∴ nyx ~/pepper $ pepper -H -v '*' cmd.run 'whoami' -a pam --username loren
    Password:
    global name 'args' is not defined
    Uncaught Pepper error (increase verbosity for the full traceback).