### PR TITLE
attempt to have library work with python2 and python3

### DIFF
--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -20,7 +20,10 @@ except ImportError:
 
 logger = logging.getLogger('pepper')
 
-class PepperException(Exception): pass
+
+class PepperException(Exception):
+    pass
+
 
 class Pepper(object):
     '''
@@ -79,12 +82,12 @@ class Pepper(object):
             'X-Requested-With': 'XMLHttpRequest',
         }
 
-        handler=HTTPHandler(debuglevel=1 if self.debug_http else 0)
+        handler = HTTPHandler(debuglevel=1 if self.debug_http else 0)
         opener = build_opener(handler)
         install_opener(opener)
 
         # Build POST data
-        if data != None:
+        if data is not None:
             postdata = json.dumps(data).encode()
             clen = len(postdata)
 
@@ -94,10 +97,10 @@ class Pepper(object):
 
         if not url.startswith('http'):
             raise PepperException("salt-api URL missing HTTP(s) protocol: {0}"
-                    .format(self.api_url))
+                                  .format(self.api_url))
 
         # Add POST data to request
-        if data != None:
+        if data is not None:
             req.add_header('Content-Length', clen)
 
         # Add auth header to request
@@ -137,7 +140,7 @@ class Pepper(object):
         return self.req(path, lowstate)
 
     def local(self, tgt, fun, arg=None, kwarg=None, expr_form='glob',
-            timeout=None, ret=None):
+              timeout=None, ret=None):
         '''
         Run a single command using the ``local`` client
 
@@ -166,7 +169,8 @@ class Pepper(object):
 
         return self.low([low], path='/')
 
-    def local_async(self, tgt, fun, arg=None, kwarg=None, expr_form='glob', timeout=None, ret=None):
+    def local_async(self, tgt, fun, arg=None, kwarg=None, expr_form='glob',
+                    timeout=None, ret=None):
         '''
         Run a single command using the ``local_async`` client
 

--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -63,7 +63,7 @@ class Pepper(object):
         :param debug_http: Add a flag to urllib2 to output the HTTP exchange
         '''
         self.api_url = api_url
-        self.debug_http = debug_http
+        self.debug_http = int(debug_http)
         self.auth = {}
 
     def req(self, path, data=None):
@@ -82,7 +82,7 @@ class Pepper(object):
             'X-Requested-With': 'XMLHttpRequest',
         }
 
-        handler = HTTPHandler(debuglevel=1 if self.debug_http else 0)
+        handler = HTTPHandler(debuglevel=self.debug_http)
         opener = build_opener(handler)
         install_opener(opener)
 


### PR DESCRIPTION
This is a working change for the Pepper library to work with python2 and 3.
See #24 for initial issue raised.