### PR TITLE
Honor cookies

### DIFF
--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -13,6 +13,7 @@ try:
         install_opener, build_opener
     from urllib.error import HTTPError, URLError
     import urllib.parse as urlparse
+    SUPPORTS_COOKIES = False
 except ImportError:
     from urllib2 import HTTPHandler, Request, urlopen, install_opener, build_opener, \
         HTTPError, URLError, HTTPCookieProcessor

--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -231,6 +231,4 @@ class Pepper(object):
             'password': password,
             'eauth': eauth}).get('return', [{}])[0]
 
-        print self.auth
-
         return self.auth


### PR DESCRIPTION
We need to honor cookies sent back as we put multiple salt-api instances behind HAProxy.

Definitely open to suggestions on better ways to do this.