### PR TITLE
Add kerberos authentification support in libpepper.py

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -185,6 +185,9 @@ class PepperCli(object):
         if self.options.saltapiurl:
             results['SALTAPI_URL'] = self.options.saltapiurl
 
+        if results['SALTAPI_EAUTH'] == 'kerberos':
+            results['SALTAPI_PASS'] = None
+
         if self.options.eauth:
             results['SALTAPI_EAUTH'] = self.options.eauth
             if self.options.username is None:


### PR DESCRIPTION
requires requests_kerberos (related to #34)

Here is a pull request to start discussion on how to implement this in pepper. 

There is documentation missing obviously, I'll add that once we agree on how to do this.

I think  a much cleaner way to do this would be to convert all ``def req(`` to use requests and then the "optionnal" keberos authentication would be much more lightweight and I think ``def req`` would be cleaner. 