### PR TITLE
Make polling behavior optional

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -72,7 +72,10 @@ class PepperCli(object):
                 "Mimic the ``salt`` CLI")
 
         optgroup.add_option('-t', '--timeout', dest='timeout', type ='int',
-            help="Specify wait time (in seconds) before returning control to the shell")
+            help=textwrap.dedent('''\
+            Specify wait time (in seconds) before returning control to the
+            shell'''))
+
         optgroup.add_option('--client', dest='client', default='local',
             help=textwrap.dedent('''\
             specify the salt-api client to use (local, local_async,

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -73,6 +73,10 @@ class PepperCli(object):
 
         optgroup.add_option('-t', '--timeout', dest='timeout', type ='int',
             help="Specify wait time (in seconds) before returning control to the shell")
+        optgroup.add_option('--client', dest='client', default='local',
+            help=textwrap.dedent('''\
+            specify the salt-api client to use (local, local_async,
+            runner, etc)'''))
 
         # optgroup.add_option('--out', '--output', dest='output',
         #        help="Specify the output format for the command output")


### PR DESCRIPTION
We can't run unexpected commands as the default behavior. This must be gated behind a CLI flag with a warning.