### PR TITLE
Runner interface only supports keyword arguments

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -254,6 +254,11 @@ class PepperCli(object):
             low['tgt'] = args.pop(0)
             low['fun'] = args.pop(0)
             low['arg'] = args
+        elif client.startswith('runner'):
+            low['fun'] = args.pop(0)
+            for arg in args:
+                key, value = arg.split('=')
+                low[key] = value
         else:
             if len(args) < 1:
                 self.parser.error("Command not specified")


### PR DESCRIPTION
Based on https://docs.saltstack.com/en/latest/topics/netapi/index.html#salt.netapi.NetapiClient.runner
the runner only supports keyword arguments. This change enable us to run
something like:

```
pepper -a pam -u http://salt-api.ourdomain --client=runner state.orchestrate mods=orchestration.bootstrap-puppet
```