### PR TITLE
Support environment definition

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -123,6 +123,9 @@ class PepperCli(object):
                 action='store_const', const='range',
             help="Target based on range expression")
 
+        optgroup.add_option('-e', '--environment', dest='saltenv',
+                            help='Salt environment to use')
+
         return optgroup
 
     def add_authopts(self):
@@ -245,6 +248,9 @@ class PepperCli(object):
 
         client = self.options.client
         low = {'client': client}
+
+        if self.options.saltenv is not None:
+            low['kwarg'] = {'saltenv': self.options.saltenv}
 
         if client.startswith('local'):
             if len(args) < 2:

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -249,12 +249,13 @@ class PepperCli(object):
         client = self.options.client
         low = {'client': client}
 
-        if self.options.saltenv is not None:
-            low['kwarg'] = {'saltenv': self.options.saltenv}
 
         if client.startswith('local'):
             if len(args) < 2:
                 self.parser.error("Command or target not specified")
+
+            if self.options.saltenv is not None:
+                low['kwarg'] = {'saltenv': self.options.saltenv}
 
             low['expr_form'] = self.options.expr_form
             low['tgt'] = args.pop(0)
@@ -262,9 +263,13 @@ class PepperCli(object):
             low['arg'] = args
         elif client.startswith('runner'):
             low['fun'] = args.pop(0)
+
+            if self.options.saltenv is not None:
+                low['saltenv'] = self.options.saltenv
             for arg in args:
                 key, value = arg.split('=')
                 low[key] = value
+
         else:
             if len(args) < 1:
                 self.parser.error("Command not specified")


### PR DESCRIPTION
Enable user to specify an environment.
saltenv can be given as a kwarg to force the environment.

But still when we run

```
bin/pepper -a pam -v -H -u http://192.168.30.100:8000/ -e base '*' test.ping
```

 get this:

```
{
    "return": [
        {
            "jenkinsslave.sandbox.srv.cirb.lan": "ERROR executing 'test.ping': The following keyword arguments are not valid: saltenv=base", 
            "postgres-server.sandbox.srv.cirb.lan": "ERROR executing 'test.ping': The following keyword arguments are not valid: saltenv=base", 
            "puppetdb.sandbox.srv.cirb.lan": "ERROR executing 'test.ping': The following keyword arguments are not valid: saltenv=base", 
            "puppetmaster.sandbox.srv.cirb.lan": "ERROR executing 'test.ping': The following keyword arguments are not valid: saltenv=base", 
            "saltmaster.sandbox.srv.cirb.lan": "ERROR executing 'test.ping': The following keyword arguments are not valid: saltenv=base", 
            "sonarqube.sandbox.srv.cirb.lan": "ERROR executing 'test.ping': The following keyword arguments are not valid: saltenv=base"
        }
    ]
}
```