### PR TITLE
Feature/python 3 support

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -324,7 +324,7 @@ class PepperCli(object):
         load = self.parse_cmd()
         creds = iter(self.parse_login())
 
-        api = pepper.Pepper(creds.next(), debug_http=self.options.debug_http, ignore_ssl_errors=self.options.ignore_ssl_certificate_errors)
+        api = pepper.Pepper(creds.__next__(), debug_http=self.options.debug_http, ignore_ssl_errors=self.options.ignore_ssl_certificate_errors)
         auth = api.login(*list(creds))
 
         if self.options.fail_if_minions_dont_respond:

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -191,7 +191,7 @@ class PepperCli(object):
             'SALTAPI_EAUTH': 'auto',
         }
 
-        config = ConfigParser.RawConfigParser()
+        config = ConfigParser(interpolation=None)
         config.read(self.options.config)
 
         # read file

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -8,7 +8,7 @@ import logging
 import optparse
 import os
 import textwrap
-import ConfigParser
+from configparser import ConfigParser
 import getpass
 import time
 

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -332,7 +332,7 @@ class PepperCli(object):
         load = self.parse_cmd()
         creds = iter(self.parse_login())
 
-        api = pepper.Pepper(creds.__next__(), debug_http=self.options.debug_http, ignore_ssl_errors=self.options.ignore_ssl_certificate_errors)
+        api = pepper.Pepper(next(creds), debug_http=self.options.debug_http, ignore_ssl_errors=self.options.ignore_ssl_certificate_errors)
         auth = api.login(*list(creds))
 
         if self.options.fail_if_minions_dont_respond:

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -8,9 +8,14 @@ import logging
 import optparse
 import os
 import textwrap
-from configparser import ConfigParser
 import getpass
 import time
+try:
+    # Python 3
+    from configparser import ConfigParser
+except ImportError:
+    # Python 2
+    import ConfigParser
 
 import pepper
 
@@ -191,7 +196,10 @@ class PepperCli(object):
             'SALTAPI_EAUTH': 'auto',
         }
 
-        config = ConfigParser(interpolation=None)
+        try:
+            config = ConfigParser(interpolation=None)
+        except TypeError as e:
+            config = ConfigParser.RawConfigParser()
         config.read(self.options.config)
 
         # read file

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ def parse_version_tag(tag):
     Returns a tuple of the version number, number of commits (if any), and the
     Git SHA (if available).
     '''
+    tag = tag.decode()
     if not tag or '-g' not in tag:
         return tag, None, None
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ def parse_version_tag(tag):
     Returns a tuple of the version number, number of commits (if any), and the
     Git SHA (if available).
     '''
-    tag = tag.decode()
+    if isinstance(tag, bytes):
+        tag = tag.decode()
     if not tag or '-g' not in tag:
         return tag, None, None
 


### PR DESCRIPTION
Addresses issue #24. It may not fix it entirely; I cannot tell without any tests. However it seems to do so. I can now run the cli on both Python 2 and Python 3.