### PR TITLE
Allow '=' in runner parameters values

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -275,7 +275,7 @@ class PepperCli(object):
         elif client.startswith('runner'):
             low['fun'] = args.pop(0)
             for arg in args:
-                key, value = arg.split('=')
+                key, value = arg.split('=', 1)
                 low[key] = value
         else:
             if len(args) < 1:


### PR DESCRIPTION
Without the fix you will get ValueError: too many values to unpack if you have '=' in parameter value