### PR TITLE
Create section install_requires and add configparser to it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ import json
 import os
 import re
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
 from distutils.dist import Distribution
 from distutils.command import sdist, install_data
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup_kwargs = {
     },
     'scripts': [
         'scripts/pepper',
+    ],
+    'install_requires': [
+        'configparser'
     ]
 }
 


### PR DESCRIPTION
configparser seems to have to be installed but it is not included in requirements of this package 