### PR TITLE
Fix JSON input encoding

### DIFF
--- a/pepper/__init__.py
+++ b/pepper/__init__.py
@@ -14,7 +14,8 @@ try:
     vfile = os.path.join(os.path.dirname(__file__), 'version.json')
 
     with open(vfile, 'rb') as f:
-        ret = json.load(f)
+        data = f.read().decode("utf-8")
+        ret = json.loads(data)
         version = ret.get('version')
         sha = ret.get('sha')
 except IOError:


### PR DESCRIPTION
Avoid

> TypeError: the JSON object must be str, not 'bytes'

in Python 3.5.1 by encoding input data to utf-8 string.