### PR TITLE
Do not sort the JSON output of saltstack

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -351,4 +351,4 @@ class PepperCli(object):
             ret = api.low(load)
             exit_code = 0
 
-        return (exit_code, json.dumps(ret, sort_keys=True, indent=4))
+        return (exit_code, json.dumps(ret, indent=4))


### PR DESCRIPTION
The default behavior of sorting the output makes debugging pretty complicated, as the order of the executed states is completely messed up.
Let's show the output as it comes from the master.