### PR TITLE
Resolves reference error in req()

### DIFF
--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -110,6 +110,8 @@ class Pepper(object):
         if data is not None:
             postdata = json.dumps(data).encode()
             clen = len(postdata)
+        else:
+            postdata = None
 
         # Create request object
         url = self._construct_url(path)


### PR DESCRIPTION
If one uses `req` to call Salt API endpoints rather than run commands then `req` is not called with a value for `data`; this would break because the variable `postdata`, which must be defined, is only defined if `data is not None`.