### PR TITLE
Re-add the logger verbosity code

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -384,6 +384,10 @@ class PepperCli(object):
         '''
         self.parse()
 
+        # move logger instantiation to method?
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(max(logging.ERROR - (self.options.verbose * 10), 1))
+
         load = self.parse_cmd()
 
         api = pepper.Pepper(


### PR DESCRIPTION
This was accidentally deleted in a commit with some code-shuffling.