### PR TITLE
Add --run-uri flag to use the /token and /run endpoints instead of session tokens

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -466,7 +466,6 @@ class PepperCli(object):
                 if api.auth['expire'] < time.time()+30:
                     logger.error('Login token expired')
                     raise Exception('Login token expired')
-                api.req('/stats')
             except Exception as e:
                 if e.args[0] is not 2:
                     logger.error('Unable to load login token from {0} {1}'.format(token_file, str(e)))

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -468,7 +468,8 @@ class PepperCli(object):
                     raise Exception('Login token expired')
             except Exception as e:
                 if e.args[0] is not 2:
-                    logger.error('Unable to load login token from {0} {1}'.format(token_file, str(e)))
+                    logger.error('Unable to load login token from {0} {1}'
+                        .format(token_file, str(e)))
                 auth = login(*self.parse_login())
                 try:
                     oldumask = os.umask(0)
@@ -476,7 +477,8 @@ class PepperCli(object):
                     with os.fdopen(fdsc, 'wt') as f:
                         json.dump(auth, f)
                 except Exception as e:
-                    logger.error('Unable to save token to {0} {1}'.format(token_file, str(e)))
+                    logger.error('Unable to save token to {0} {1}'
+                        .format(token_file, str(e)))
                 finally:
                     os.umask(oldumask)
         else:

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -207,6 +207,13 @@ class PepperCli(object):
                 generated and made available for the period defined in the Salt
                 Master."""))
 
+        optgroup.add_option('-r', '--run-uri', default=False,
+            dest='userun', action='store_true',
+            help=textwrap.dedent("""\
+                Use an eauth token from /token and send commands through the
+                /run URL instead of the traditional session token
+                approach."""))
+
         optgroup.add_option('-x', dest='cache',
             default=os.environ.get('PEPPERCACHE',
                 os.path.join(os.path.expanduser('~'), '.peppercache')),

--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -57,7 +57,10 @@ class Pepper(object):
               u'ms-4': True}]}
 
     '''
-    def __init__(self, api_url='https://localhost:8000', debug_http=False, ignore_ssl_errors=False):
+    def __init__(self,
+            api_url='https://localhost:8000',
+            debug_http=False,
+            ignore_ssl_errors=False):
         '''
         Initialize the class with the URL of the API
 
@@ -188,7 +191,8 @@ class Pepper(object):
         :rtype: dictionary
 
         '''
-        if (hasattr(data, 'get') and data.get('eauth') == 'kerberos') or self.auth.get('eauth') == 'kerberos':
+        if ((hasattr(data, 'get') and data.get('eauth') == 'kerberos')
+                or self.auth.get('eauth') == 'kerberos'):
             return self.req_requests(path, data)
 
         headers = {

--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -438,17 +438,24 @@ class Pepper(object):
 
         return self.low([low])
 
-    def login(self, username, password, eauth):
+    def _send_auth(self, path, **kwargs):
+        return self.req(path, kwargs)
+
+    def login(self, **kwargs):
         '''
         Authenticate with salt-api and return the user permissions and
         authentication token or an empty dict
 
         '''
-        self.auth = self.req('/login', {
-            'username': username,
-            'password': password,
-            'eauth': eauth}).get('return', [{}])[0]
+        self.auth = self._send_auth('/login', **kwargs).get('return', [{}])[0]
+        return self.auth
 
+    def token(self, **kwargs):
+        '''
+        Get an eauth token from Salt for use with the /run URL
+
+        '''
+        self.auth = self._send_auth('/token', **kwargs)[0]
         return self.auth
 
     def _construct_url(self, path):

--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -328,7 +328,7 @@ class Pepper(object):
         if ret:
             low['ret'] = ret
 
-        return self.low([low], path='/')
+        return self.low([low])
 
     def local_async(self, tgt, fun, arg=None, kwarg=None, expr_form='glob',
                     timeout=None, ret=None):
@@ -358,7 +358,7 @@ class Pepper(object):
         if ret:
             low['ret'] = ret
 
-        return self.low([low], path='/')
+        return self.low([low])
 
     def local_batch(self, tgt, fun, arg=None, kwarg=None, expr_form='glob',
                     batch='50%', ret=None):
@@ -388,7 +388,7 @@ class Pepper(object):
         if ret:
             low['ret'] = ret
 
-        return self.low([low], path='/')
+        return self.low([low])
 
     def lookup_jid(self, jid):
         '''
@@ -415,7 +415,7 @@ class Pepper(object):
 
         low.update(kwargs)
 
-        return self.low([low], path='/')
+        return self.low([low])
 
     def wheel(self, fun, arg=None, kwarg=None, **kwargs):
         '''
@@ -436,7 +436,7 @@ class Pepper(object):
 
         low.update(kwargs)
 
-        return self.low([low], path='/')
+        return self.low([low])
 
     def login(self, username, password, eauth):
         '''

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+'''
+These integration tests will execute non-destructive commands against a real
+Salt and salt-api instance. Those must be set up and started independently.
+This will take several minutes to run.
+
+Usage:
+
+SALTAPI_URL=http://localhost:8000 \
+SALTAPI_USER=saltdev \
+SALTAPI_PASS=saltdev \
+SALTAPI_EAUTH=auto \
+    python -m unittest tests.integration
+'''
+import itertools
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+
+try:
+    SALTAPI_URL = os.environ['SALTAPI_URL']
+    SALTAPI_USER = os.environ['SALTAPI_USER']
+    SALTAPI_PASS = os.environ['SALTAPI_PASS']
+    SALTAPI_EAUTH = os.environ['SALTAPI_EAUTH']
+except KeyError:
+    raise SystemExit('The following environment variables must be set: '
+        'SALTAPI_URL, SALTAPI_USER, SALTAPI_PASS, SALTAPI_EAUTH.')
+
+
+def _pepper(*args):
+    '''
+    Wrapper to invoke Pepper with common params and inside an empty env
+    '''
+    def_args = [
+        'pepper',
+        '--saltapi-url={0}'.format(SALTAPI_URL),
+        '--username={0}'.format(SALTAPI_USER),
+        '--password={0}'.format(SALTAPI_PASS),
+        '--eauth={0}'.format(SALTAPI_EAUTH),
+    ]
+
+    return subprocess.check_output(itertools.chain(def_args, args))
+
+
+class TestVanilla(unittest.TestCase):
+    def _pepper(self, *args):
+        return json.loads(_pepper(*args))['return'][0]
+
+    def test_local(self):
+        '''Sanity-check: Has at least one minion'''
+        ret = self._pepper('*', 'test.ping')
+        self.assertTrue(ret.values()[0])
+
+    def test_run(self):
+        '''Run command via /run URI'''
+        ret = self._pepper('--run-uri', '*', 'test.ping')
+        self.assertTrue(ret.values()[0])
+
+    def test_long_local(self):
+        '''Test a long call blocks until the return'''
+        ret = self._pepper('*', 'test.sleep', '30')
+        self.assertTrue(ret.values()[0])
+
+
+class TestPoller(unittest.TestCase):
+    def _pepper(self, *args):
+        return _pepper(*args).splitlines()[0]
+
+    def test_local_poll(self):
+        '''Test the returns poller for localclient'''
+        ret = self._pepper('--run-uri', '--fail-if-incomplete', '*', 'test.sleep', '30')
+        self.assertTrue('True' in ret)
+
+
+class TestTokens(unittest.TestCase):
+    def setUp(self):
+        self.tokdir = tempfile.mkdtemp()
+        self.tokfile = os.path.join(self.tokdir, 'peppertok.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.tokdir)
+
+    def _pepper(self, *args):
+        return json.loads(_pepper(*args))['return'][0]
+
+    def test_local_token(self):
+        '''Test local execution with token file'''
+        ret = self._pepper('-x', self.tokfile,
+                '--make-token', '--run-uri', '*', 'test.ping')
+        self.assertTrue(ret.values()[0])
+
+    def test_runner_token(self):
+        '''Test runner execution with token file'''
+        ret = self._pepper('-x', self.tokfile,
+                '--make-token', '--run-uri',
+                '--client', 'runner', 'test.metasyntactic')
+        self.assertTrue(ret[0] == 'foo')
+
+    def test_token_expire(self):
+        '''Test token override param'''
+        now = time.time()
+        self._pepper('-x', self.tokfile, '--make-token', '--run-uri',
+                '--token-expire', '94670856',
+                '*', 'test.ping')
+
+        with open(self.tokfile, 'r') as f:
+            token = json.load(f)
+            diff = (now + float(94670856)) - token['expire']
+            # Allow for 10-second window between request and master-side auth.
+            self.assertTrue(diff < 10)


### PR DESCRIPTION
Usage example to save the token locally (`-T`), authenticate via `/token` and invoke functions via `/run` (`--run-uri`), and manually specify the eauth token expiration (in seconds; must be whitelisted on the master) (`--token-expire`).

```bash
% pepper -T --run-uri --token-expire=94670856 --client runner test.metasyntactic
```