### PR TITLE
Add MANIFEST.in to include license and readme in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.rst


### PR DESCRIPTION
License file should be always present in source distribution.
It's also good idea to include readme as well.