### PR TITLE
Add formatting using salt outputters if salt is installed

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -42,6 +42,7 @@ class PepperCli(object):
         self.parser.option_groups.extend([self.add_globalopts(),
             self.add_tgtopts(),
             self.add_authopts()])
+        self.parse()
 
     def get_parser(self):
         return optparse.OptionParser(
@@ -59,6 +60,14 @@ class PepperCli(object):
             help=textwrap.dedent('''\
                 Configuration file location. Default is a file path in the
                 "PEPPERRC" environment variable or ~/.pepperrc.'''))
+
+        self.parser.add_option('-m', dest='master',
+            default=os.environ.get('MASTER_CONFIG',
+                os.path.join(os.path.expanduser('~'), '.config', 'pepper', 'master')),
+            help=textwrap.dedent('''\
+                Master Configuration file location for configuring outputters.
+                default: ~/.config/pepper/master
+            '''))
 
         self.parser.add_option('-v', dest='verbose', default=0, action='count',
             help=textwrap.dedent('''\
@@ -506,8 +515,6 @@ class PepperCli(object):
         '''
         Parse all arguments and call salt-api
         '''
-        self.parse()
-
         # move logger instantiation to method?
         logger.addHandler(logging.StreamHandler())
         logger.setLevel(max(logging.ERROR - (self.options.verbose * 10), 1))

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -377,6 +377,7 @@ class PepperCli(object):
             low['fun'] = args.pop(0)
             low['batch'] = self.options.batch
             low['arg'] = args
+            low['full_return'] = True
         elif client.startswith('runner'):
             low['fun'] = args.pop(0)
             for arg in args:

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -69,6 +69,12 @@ class PepperCli(object):
                 default: ~/.config/pepper/master
             '''))
 
+        self.parser.add_option('-o', '--out', dest='output',
+            default=None,
+            help=textwrap.dedent('''\
+                Salt outputter to use for printing out returns.
+            '''))
+
         self.parser.add_option('-v', dest='verbose', default=0, action='count',
             help=textwrap.dedent('''\
                 Increment output verbosity; may be specified multiple times'''))

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -55,11 +55,19 @@ class Pepper(object):
                             salt.output.display_output(ret['data'], ret.get('outputter', 'nested'), opts=self.opts)
                         else:
                             for minionid, minionret in ret.items():
-                                salt.output.display_output(
-                                    {minionid: minionret['ret']},
-                                    minionret.get('out', self.output),
-                                    opts=self.opts
-                                )
+                                if isinstance(minionret, dict) and 'ret' in minionret:
+                                    # version >= 2017.7
+                                    salt.output.display_output(
+                                        {minionid: minionret['ret']},
+                                        minionret.get('out', self.output),
+                                        opts=self.opts
+                                    )
+                                else:
+                                    salt.output.display_output(
+                                        {minionid: minionret},
+                                        self.output,
+                                        opts=self.opts
+                                    )
                 else:
                     print(result)
                 if exit_code is not None:

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -35,6 +35,7 @@ class Pepper(object):
             cli = PepperCli()
             for exit_code, result in cli.run():
                 if HAS_SALT:
+                    logger.info('Use Salt outputters')
                     if not hasattr(self, 'opts'):
                         self.opts = salt.config.client_config('/etc/salt/master')
                     if not hasattr(self, 'modules'):
@@ -44,7 +45,8 @@ class Pepper(object):
                     except (KeyError, AttributeError, TypeError):
                         oput = 'nested'
                     for ret in json.loads(result)['return']:
-                        salt.output.display_output(ret, oput, opts=self.opts)
+                        for minionid, minionret in ret.items():
+                            salt.output.display_output({minionid: minionret}, oput, opts=self.opts)
                 else:
                     print(result)
                 if exit_code is not None:

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -30,23 +30,31 @@ logger = logging.getLogger('pepper')
 logger.addHandler(NullHandler())
 
 class Pepper(object):
+    def __init__(self):
+        self.cli = PepperCli()
+        self.opts = salt.config.client_config('/etc/salt/master')
+
+    @property
+    def output(self, ret):
+        if not hasattr(self, 'modules'):
+            self.modules = salt.loader.minion_mods(self.opts)
+        try:
+            oput = self.modules[self.cli.args[1]].__outputter__
+        except (KeyError, AttributeError, TypeError):
+            oput = 'nested'
+        return oput
+
     def __call__(self):
         try:
-            cli = PepperCli()
-            for exit_code, result in cli.run():
+            for exit_code, result in self.cli.run():
                 if HAS_SALT:
                     logger.info('Use Salt outputters')
-                    if not hasattr(self, 'opts'):
-                        self.opts = salt.config.client_config('/etc/salt/master')
-                    if not hasattr(self, 'modules'):
-                        self.modules = salt.loader.minion_mods(self.opts)
-                    try:
-                        oput = self.modules[cli.args[1]].__outputter__
-                    except (KeyError, AttributeError, TypeError):
-                        oput = 'nested'
                     for ret in json.loads(result)['return']:
-                        for minionid, minionret in ret.items():
-                            salt.output.display_output({minionid: minionret}, oput, opts=self.opts)
+                        if 'data' in ret:
+                            salt.output.display_output(ret['data'], ret.get('outputter', 'nested'), opts=self.opts)
+                        else:
+                            for minionid, minionret in ret.items():
+                                salt.output.display_output({minionid: minionret}, self.get_output(), opts=self.opts)
                 else:
                     print(result)
                 if exit_code is not None:

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -29,13 +29,14 @@ logging.basicConfig(format='%(levelname)s %(asctime)s %(module)s: %(message)s')
 logger = logging.getLogger('pepper')
 logger.addHandler(NullHandler())
 
+
 class Pepper(object):
     def __init__(self):
         self.cli = PepperCli()
         self.opts = salt.config.client_config('/etc/salt/master')
 
     @property
-    def output(self, ret):
+    def output(self):
         if not hasattr(self, 'modules'):
             self.modules = salt.loader.minion_mods(self.opts)
         try:
@@ -54,7 +55,11 @@ class Pepper(object):
                             salt.output.display_output(ret['data'], ret.get('outputter', 'nested'), opts=self.opts)
                         else:
                             for minionid, minionret in ret.items():
-                                salt.output.display_output({minionid: minionret}, self.get_output(), opts=self.opts)
+                                salt.output.display_output(
+                                    {minionid: minionret['ret']},
+                                    minionret.get('out', self.output),
+                                    opts=self.opts
+                                )
                 else:
                     print(result)
                 if exit_code is not None:

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -5,10 +5,19 @@ A CLI interface to a remote salt-api instance
 from __future__ import print_function
 
 import sys
+import json
 import logging
 
 from pepper.cli import PepperCli
 from pepper import PepperException
+
+try:
+    import salt.loader
+    import salt.config
+    import salt.output
+    HAS_SALT = True
+except ImportError:
+    HAS_SALT = False
 
 try:
     from logging import NullHandler
@@ -20,22 +29,38 @@ logging.basicConfig(format='%(levelname)s %(asctime)s %(module)s: %(message)s')
 logger = logging.getLogger('pepper')
 logger.addHandler(NullHandler())
 
+class Pepper(object):
+    def __call__(self):
+        try:
+            cli = PepperCli()
+            for exit_code, result in cli.run():
+                if HAS_SALT:
+                    if not hasattr(self, 'opts'):
+                        self.opts = salt.config.client_config('/etc/salt/master')
+                    if not hasattr(self, 'modules'):
+                        self.modules = salt.loader.minion_mods(self.opts)
+                    try:
+                        oput = self.modules[cli.args[1]].__outputter__
+                    except (KeyError, AttributeError, TypeError):
+                        oput = 'nested'
+                    for ret in json.loads(result)['return']:
+                        salt.output.display_output(ret, oput, opts=self.opts)
+                else:
+                    print(result)
+                if exit_code is not None:
+                    raise SystemExit(exit_code)
+        except PepperException as exc:
+            print('Pepper error: {0}'.format(exc), file=sys.stderr)
+            raise SystemExit(1)
+        except KeyboardInterrupt:
+            # TODO: mimic CLI and output JID on ctrl-c
+            raise SystemExit(0)
+        except Exception as e:
+            print(e)
+            print('Uncaught Pepper error (increase verbosity for the full traceback).',
+                    file=sys.stderr)
+            logger.debug('Uncaught traceback:', exc_info=True)
+            raise SystemExit(1)
+
 if __name__ == '__main__':
-    try:
-        cli = PepperCli()
-        for exit_code, result in cli.run():
-            print(result)
-            if exit_code is not None:
-                raise SystemExit(exit_code)
-    except PepperException as exc:
-        print('Pepper error: {0}'.format(exc), file=sys.stderr)
-        raise SystemExit(1)
-    except KeyboardInterrupt:
-        # TODO: mimic CLI and output JID on ctrl-c
-        raise SystemExit(0)
-    except Exception as e:
-        print(e)
-        print('Uncaught Pepper error (increase verbosity for the full traceback).',
-                file=sys.stderr)
-        logger.debug('Uncaught traceback:', exc_info=True)
-        raise SystemExit(1)
+    Pepper()()

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -33,7 +33,7 @@ logger.addHandler(NullHandler())
 class Pepper(object):
     def __init__(self):
         self.cli = PepperCli()
-        self.opts = salt.config.client_config('/etc/salt/master')
+        self.opts = salt.config.client_config(self.cli.options.master)
 
     @property
     def output(self):

--- a/scripts/pepper
+++ b/scripts/pepper
@@ -52,20 +52,24 @@ class Pepper(object):
                     logger.info('Use Salt outputters')
                     for ret in json.loads(result)['return']:
                         if 'data' in ret:
-                            salt.output.display_output(ret['data'], ret.get('outputter', 'nested'), opts=self.opts)
+                            salt.output.display_output(
+                                ret['data'],
+                                self.cli.options.output or ret.get('outputter', 'nested'),
+                                opts=self.opts
+                            )
                         else:
                             for minionid, minionret in ret.items():
                                 if isinstance(minionret, dict) and 'ret' in minionret:
                                     # version >= 2017.7
                                     salt.output.display_output(
                                         {minionid: minionret['ret']},
-                                        minionret.get('out', self.output),
+                                        self.cli.options.output or minionret.get('out', self.output),
                                         opts=self.opts
                                     )
                                 else:
                                     salt.output.display_output(
                                         {minionid: minionret},
-                                        self.output,
+                                        self.cli.options.output or self.output,
                                         opts=self.opts
                                     )
                 else:


### PR DESCRIPTION
If salt is installed, format using `salt.output.display_output`

For runners, I check that 'data' is present, and then use the 'outputter' keyword to get the outputter to print.

For modules, if 'out' is passed with the `full_return` for 2017.7 and newer, I use out, otherwise, we load the module from salt, and check its '__outputter__' variable.

