### PR TITLE
Validate minions retcode results

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -326,30 +326,30 @@ class PepperCli(object):
 
         return optgroup
 
-
     def add_retcodeopts(self):
         '''
         ret code validation options
         '''
-        optgroup = optparse.OptionGroup(self.parser, "retcode Field Validation Options",
-                textwrap.dedent("""\
-                Validate return.HOST.retcode fields
-                """))
+        optgroup = optparse.OptionGroup(
+            self.parser, "retcode Field Validation Options", "Validate return.HOST.retcode fields")
 
-        optgroup.add_option('--fail-any', dest='fail_any', action='store_true',
-                help="Fail if any of retcode field is non zero.")
+        optgroup.add_option(
+            '--fail-any', dest='fail_any', action='store_true',
+            help="Fail if any of retcode field is non zero.")
 
-        optgroup.add_option('--fail-any-none', dest='fail_any_none', action='store_true',
-                help="Fail if any of retcode field is non zero or there is no retcode at all.")
+        optgroup.add_option(
+            '--fail-any-none', dest='fail_any_none', action='store_true',
+            help="Fail if any of retcode field is non zero or there is no retcode at all.")
 
-        optgroup.add_option('--fail-all', dest='fail_all', action='store_true',
-                help="Fail if all retcode fields are non zero.")
+        optgroup.add_option(
+            '--fail-all', dest='fail_all', action='store_true',
+            help="Fail if all retcode fields are non zero.")
 
-        optgroup.add_option('--fail-all-none', dest='fail_all_none', action='store_true',
-                help="Fail if all retcode fields are non zero or there is no retcode at all.")
+        optgroup.add_option(
+            '--fail-all-none', dest='fail_all_none', action='store_true',
+            help="Fail if all retcode fields are non zero or there is no retcode at all.")
 
         return optgroup
-
 
     def get_login_details(self):
         '''

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -41,8 +41,8 @@ class PepperCli(object):
         self.parser.option_groups.extend([
             self.add_globalopts(),
             self.add_tgtopts(),
-            self.add_authopts()
-        ])
+            self.add_authopts(),
+            self.add_retcodeopts()])
         self.parse()
 
     def get_parser(self):
@@ -125,6 +125,12 @@ class PepperCli(object):
         )
 
         self.options, self.args = self.parser.parse_args()
+
+        option_names = ["fail_any", "fail_any_none", "fail_all", "fail_all_none"]
+        toggled_options = [name for name in option_names if getattr(self.options, name)]
+        if len(toggled_options) > 1:
+            s = repr(toggled_options).strip("[]")
+            self.parser.error("Options %s are mutually exclusive" % s)
 
     def add_globalopts(self):
         '''
@@ -319,6 +325,31 @@ class PepperCli(object):
         )
 
         return optgroup
+
+
+    def add_retcodeopts(self):
+        '''
+        ret code validation options
+        '''
+        optgroup = optparse.OptionGroup(self.parser, "retcode Field Validation Options",
+                textwrap.dedent("""\
+                Validate return.HOST.retcode fields
+                """))
+
+        optgroup.add_option('--fail-any', dest='fail_any', action='store_true',
+                help="Fail if any of retcode field is non zero.")
+
+        optgroup.add_option('--fail-any-none', dest='fail_any_none', action='store_true',
+                help="Fail if any of retcode field is non zero or there is no retcode at all.")
+
+        optgroup.add_option('--fail-all', dest='fail_all', action='store_true',
+                help="Fail if all retcode fields are non zero.")
+
+        optgroup.add_option('--fail-all-none', dest='fail_all_none', action='store_true',
+                help="Fail if all retcode fields are non zero or there is no retcode at all.")
+
+        return optgroup
+
 
     def get_login_details(self):
         '''

--- a/pepper/retcode.py
+++ b/pepper/retcode.py
@@ -88,7 +88,7 @@ class PepperRetcode(object):
                 retcodes = list(minion[name].get('retcode')
                                 for name in minion if isinstance(minion[name], dict) and
                                 minion[name].get('retcode') is not None)
-                if all(r for r in retcodes if r != 0):
+                if all(r != 0 for r in retcodes):
                     return next((r for r in retcodes if r != 0), 0)
         return 0
 
@@ -111,6 +111,8 @@ class PepperRetcode(object):
                                 minion[name].get('retcode') is not None)
                 if not retcodes:
                     return -1  # there are no retcodes
-                if all(r for r in retcodes if r != 0):
+                if all(r != 0 for r in retcodes):
                     return next((r for r in retcodes if r != 0), 0)
+                else:
+                    return 0
         return -1

--- a/pepper/retcode.py
+++ b/pepper/retcode.py
@@ -64,7 +64,9 @@ class PepperRetcode(object):
                 minion = result[0]
                 retcodes = list(minion[name].get('retcode')
                                 for name in minion if minion[name].get('retcode') is not None)
-                return next((r for r in retcodes if r != 0), -1)
+                if not retcodes:
+                    return -1 # there are no retcodes
+                return next((r for r in retcodes if r != 0), 0)
         return -1
 
     @staticmethod
@@ -84,7 +86,7 @@ class PepperRetcode(object):
                 retcodes = list(minion[name].get('retcode')
                                 for name in minion if minion[name].get('retcode') is not None)
                 if all(r for r in retcodes if r != 0):
-                    return next((r for r in retcodes if r != 0), -1)
+                    return next((r for r in retcodes if r != 0), 0)
         return 0
 
     @staticmethod
@@ -103,6 +105,8 @@ class PepperRetcode(object):
                 minion = result[0]
                 retcodes = list(minion[name].get('retcode')
                                 for name in minion if minion[name].get('retcode') is not None)
+                if not retcodes:
+                    return -1 # there are no retcodes
                 if all(r for r in retcodes if r != 0):
-                    return next((r for r in retcodes if r != 0), -1)
+                    return next((r for r in retcodes if r != 0), 0)
         return -1

--- a/pepper/retcode.py
+++ b/pepper/retcode.py
@@ -44,7 +44,8 @@ class PepperRetcode(object):
             if isinstance(result[0], dict):
                 minion = result[0]
                 retcodes = list(minion[name].get('retcode')
-                                for name in minion if minion[name].get('retcode') is not None)
+                                for name in minion if isinstance(minion[name], dict) and
+                                minion[name].get('retcode') is not None)
                 return next((r for r in retcodes if r != 0), 0)
         return 0
 
@@ -63,7 +64,8 @@ class PepperRetcode(object):
             if isinstance(result[0], dict):
                 minion = result[0]
                 retcodes = list(minion[name].get('retcode')
-                                for name in minion if minion[name].get('retcode') is not None)
+                                for name in minion if isinstance(minion[name], dict) and
+                                minion[name].get('retcode') is not None)
                 if not retcodes:
                     return -1 # there are no retcodes
                 return next((r for r in retcodes if r != 0), 0)
@@ -84,7 +86,8 @@ class PepperRetcode(object):
             if isinstance(result[0], dict):
                 minion = result[0]
                 retcodes = list(minion[name].get('retcode')
-                                for name in minion if minion[name].get('retcode') is not None)
+                                for name in minion if isinstance(minion[name], dict) and
+                                minion[name].get('retcode') is not None)
                 if all(r for r in retcodes if r != 0):
                     return next((r for r in retcodes if r != 0), 0)
         return 0
@@ -104,7 +107,8 @@ class PepperRetcode(object):
             if isinstance(result[0], dict):
                 minion = result[0]
                 retcodes = list(minion[name].get('retcode')
-                                for name in minion if minion[name].get('retcode') is not None)
+                                for name in minion if isinstance(minion[name], dict) and
+                                minion[name].get('retcode') is not None)
                 if not retcodes:
                     return -1 # there are no retcodes
                 if all(r for r in retcodes if r != 0):

--- a/pepper/retcode.py
+++ b/pepper/retcode.py
@@ -67,7 +67,7 @@ class PepperRetcode(object):
                                 for name in minion if isinstance(minion[name], dict) and
                                 minion[name].get('retcode') is not None)
                 if not retcodes:
-                    return -1 # there are no retcodes
+                    return -1  # there are no retcodes
                 return next((r for r in retcodes if r != 0), 0)
         return -1
 
@@ -110,7 +110,7 @@ class PepperRetcode(object):
                                 for name in minion if isinstance(minion[name], dict) and
                                 minion[name].get('retcode') is not None)
                 if not retcodes:
-                    return -1 # there are no retcodes
+                    return -1  # there are no retcodes
                 if all(r for r in retcodes if r != 0):
                     return next((r for r in retcodes if r != 0), 0)
         return -1

--- a/pepper/retcode.py
+++ b/pepper/retcode.py
@@ -3,6 +3,106 @@ A retcode validator
 
 '''
 
+
 class PepperRetcode(object):
-    def validate(self, text):
+    '''
+    Validation container
+    '''
+
+    def validate(self, options, result):
+        '''
+        Validate result dictionary retcode values.
+
+        :param options: optparse options
+
+        :param result: dictionary from Saltstack master
+
+        :return: exit code
+        '''
+        if options.fail_any:
+            return self.validate_fail_any(result)
+        if options.fail_any_none:
+            return self.validate_fail_any_none(result)
+        if options.fail_all:
+            return self.validate_fail_all(result)
+        if options.fail_all_none:
+            return self.validate_fail_all_none(result)
         return 0
+
+    @staticmethod
+    def validate_fail_any(result):
+        '''
+        Validate result dictionary retcode values.
+        Returns 0 if no retcode keys.
+        Returns first non zero retcode if any of recodes is non zero.
+
+        :param result: dictionary from Saltstack master
+
+        :return: exit code
+        '''
+        if isinstance(result, list):
+            if isinstance(result[0], dict):
+                minion = result[0]
+                retcodes = list(minion[name].get('retcode')
+                                for name in minion if minion[name].get('retcode') is not None)
+                return next((r for r in retcodes if r != 0), 0)
+        return 0
+
+    @staticmethod
+    def validate_fail_any_none(result):
+        '''
+        Validate result dictionary retcode values.
+        Returns -1 if no retcode keys.
+        Returns first non zero retcode if any of recodes is non zero.
+
+        :param result: dictionary from Saltstack master
+
+        :return: exit code
+        '''
+        if isinstance(result, list):
+            if isinstance(result[0], dict):
+                minion = result[0]
+                retcodes = list(minion[name].get('retcode')
+                                for name in minion if minion[name].get('retcode') is not None)
+                return next((r for r in retcodes if r != 0), -1)
+        return -1
+
+    @staticmethod
+    def validate_fail_all(result):
+        '''
+        Validate result dictionary retcode values.
+        Returns 0 if no retcode keys.
+        Returns first non zero retcode if all recodes are non zero.
+
+        :param result: dictionary from Saltstack master
+
+        :return: exit code
+        '''
+        if isinstance(result, list):
+            if isinstance(result[0], dict):
+                minion = result[0]
+                retcodes = list(minion[name].get('retcode')
+                                for name in minion if minion[name].get('retcode') is not None)
+                if all(r for r in retcodes if r != 0):
+                    return next((r for r in retcodes if r != 0), -1)
+        return 0
+
+    @staticmethod
+    def validate_fail_all_none(result):
+        '''
+        Validate result dictionary retcode values.
+        Returns -1 if no retcode keys.
+        Returns first non zero retcode if all recodes are non zero.
+
+        :param result: dictionary from Saltstack master
+
+        :return: exit code
+        '''
+        if isinstance(result, list):
+            if isinstance(result[0], dict):
+                minion = result[0]
+                retcodes = list(minion[name].get('retcode')
+                                for name in minion if minion[name].get('retcode') is not None)
+                if all(r for r in retcodes if r != 0):
+                    return next((r for r in retcodes if r != 0), -1)
+        return -1

--- a/pepper/retcode.py
+++ b/pepper/retcode.py
@@ -1,0 +1,8 @@
+'''
+A retcode validator
+
+'''
+
+class PepperRetcode(object):
+    def validate(self, text):
+        return 0

--- a/pepper/script.py
+++ b/pepper/script.py
@@ -91,7 +91,7 @@ class Pepper(object):
                         print(result)
                 if exit_code is not None:
                     if exit_code == 0:
-                        return PepperRetcode().validate(result)
+                        return PepperRetcode().validate(self.cli.options, json.loads(result)['return'])
                     return exit_code
         except PepperException as exc:
             print('Pepper error: {0}'.format(exc), file=sys.stderr)

--- a/pepper/script.py
+++ b/pepper/script.py
@@ -90,7 +90,8 @@ class Pepper(object):
                     else:
                         print(result)
                 if exit_code is not None:
-                    exit_code = PepperRetcode().validate(result)
+                    if exit_code == 0:
+                        return PepperRetcode().validate(result)
                     return exit_code
         except PepperException as exc:
             print('Pepper error: {0}'.format(exc), file=sys.stderr)

--- a/pepper/script.py
+++ b/pepper/script.py
@@ -89,9 +89,8 @@ class Pepper(object):
                             print(result, file=ofile)
                     else:
                         print(result)
-                if exit_code is None or exit_code == 0:
-                    exit_code = PepperRetcode().validate(result)
                 if exit_code is not None:
+                    exit_code = PepperRetcode().validate(result)
                     return exit_code
         except PepperException as exc:
             print('Pepper error: {0}'.format(exc), file=sys.stderr)

--- a/pepper/script.py
+++ b/pepper/script.py
@@ -9,6 +9,7 @@ import json
 import logging
 
 from pepper.cli import PepperCli
+from pepper.retcode import PepperRetcode
 from pepper import PepperException
 
 try:
@@ -88,6 +89,8 @@ class Pepper(object):
                             print(result, file=ofile)
                     else:
                         print(result)
+                if exit_code is None or exit_code == 0:
+                    exit_code = PepperRetcode().validate(result)
                 if exit_code is not None:
                     return exit_code
         except PepperException as exc:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+mock
 pytest>=3.5.0
 pytest-rerunfailures
 pytest-cov

--- a/tests/unit/test_retcodes_fail_fail.py
+++ b/tests/unit/test_retcodes_fail_fail.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -38,12 +35,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -52,6 +51,7 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
@@ -59,10 +59,10 @@ def test_fail_all():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all_none():
     sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
-

--- a/tests/unit/test_retcodes_fail_fail.py
+++ b/tests/unit/test_retcodes_fail_fail.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "/bin/sh: 123: command not found",
+                "retcode": 127
+            },
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "/bin/sh: 1: 123: not found",
+                "retcode": 127
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+

--- a/tests/unit/test_retcodes_fail_none.py
+++ b/tests/unit/test_retcodes_fail_none.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "saltstack.ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -37,12 +34,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -51,12 +50,14 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
     sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))

--- a/tests/unit/test_retcodes_fail_none.py
+++ b/tests/unit/test_retcodes_fail_none.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "/bin/sh: 123: command not found",
+                "retcode": 127
+            },
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "Hello from SaltStack",
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127

--- a/tests/unit/test_retcodes_fail_pass.py
+++ b/tests/unit/test_retcodes_fail_pass.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "/bin/sh: 123: command not found",
+                "retcode": 127
+            },
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "pass",
+                "retcode": 0
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0

--- a/tests/unit/test_retcodes_fail_pass.py
+++ b/tests/unit/test_retcodes_fail_pass.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -38,12 +35,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -52,12 +51,14 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
     sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))

--- a/tests/unit/test_retcodes_none_none.py
+++ b/tests/unit/test_retcodes_none_none.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "Hello from SaltStack",
+            },
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "Hello from SaltStack",
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == -1
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == -1

--- a/tests/unit/test_retcodes_none_none.py
+++ b/tests/unit/test_retcodes_none_none.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "saltstack.ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -36,12 +33,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -50,12 +49,14 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == -1
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
     sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))

--- a/tests/unit/test_retcodes_pass_fail.py
+++ b/tests/unit/test_retcodes_pass_fail.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "saltstack.ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -38,12 +35,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -52,12 +51,14 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 127
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
     sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))

--- a/tests/unit/test_retcodes_pass_fail.py
+++ b/tests/unit/test_retcodes_pass_fail.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "pass",
+                "retcode": 0
+            },
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "/bin/sh: 123: command not found",
+                "retcode": 127
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 127
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0

--- a/tests/unit/test_retcodes_pass_none.py
+++ b/tests/unit/test_retcodes_pass_none.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "pass",
+                "retcode": 0
+            },
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "Hello from SaltStack",
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0

--- a/tests/unit/test_retcodes_pass_none.py
+++ b/tests/unit/test_retcodes_pass_none.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "saltstack.ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -37,12 +34,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -51,12 +50,14 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
     sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))

--- a/tests/unit/test_retcodes_pass_pass.py
+++ b/tests/unit/test_retcodes_pass_pass.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # Import Python Libraries
 from __future__ import print_function, unicode_literals, absolute_import
-import imp
-import os
-import subprocess
 import sys
 
 # Import Pepper Libraries
@@ -14,7 +11,7 @@ from mock import MagicMock
 
 
 PAYLOAD = {
-    "return" : [
+    "return": [
         {
             "ezh.msk.ru": {
                 "jid": "20180414193904158892",
@@ -38,12 +35,14 @@ def test_default():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_any():
     sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
+
 
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
@@ -52,6 +51,7 @@ def test_fail_any_none():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all():
@@ -59,10 +59,10 @@ def test_fail_all():
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
 
+
 @patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
 @patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
 def test_fail_all_none():
     sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
     ret_code = pepper.script.Pepper()()
     assert ret_code == 0
-

--- a/tests/unit/test_retcodes_pass_pass.py
+++ b/tests/unit/test_retcodes_pass_pass.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Import Python Libraries
+from __future__ import print_function, unicode_literals, absolute_import
+import imp
+import os
+import subprocess
+import sys
+
+# Import Pepper Libraries
+import pepper
+
+from mock import patch
+from mock import MagicMock
+
+
+PAYLOAD = {
+    "return" : [
+        {
+            "ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "pass",
+                "retcode": 0
+            },
+            "saltstack.ezh.msk.ru": {
+                "jid": "20180414193904158892",
+                "ret": "pass",
+                "retcode": 0
+            }
+        }
+    ]
+}
+
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_default():
+    sys.argv = ['pepper', '-vvv', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any():
+    sys.argv = ['pepper', '-vvv', '--fail-any', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_any_none():
+    sys.argv = ['pepper', '-vvv', '--fail-any-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all():
+    sys.argv = ['pepper', '-vvv', '--fail-all', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+
+@patch('pepper.cli.PepperCli.login', MagicMock(side_effect=lambda arg: None))
+@patch('pepper.cli.PepperCli.low', MagicMock(side_effect=lambda api, load: PAYLOAD))
+def test_fail_all_none():
+    sys.argv = ['pepper', '-vvv', '--fail-all-none', 'minion_id', 'request']
+    ret_code = pepper.script.Pepper()()
+    assert ret_code == 0
+


### PR DESCRIPTION
Previous behaviour
---

```
pepper -u https://saltstack-api.docker.ezh.msk.ru:8000 '*' cmd.run "123"; echo $?
{
    "return": [
        {
            "ezh.msk.ru": {
                "jid": "20180414193904158892",
                "ret": "/bin/sh: 123: command not found",
                "retcode": 127
            },
            "saltstack.ezh.msk.ru": {
                "jid": "20180414193904158892",
                "ret": "/bin/sh: 1: 123: not found",
                "retcode": 127
            }
        }
    ]
}
```
**Exit code 0**

New behaviour
---
```
pepper --fail-all-none -u https://saltstack-api.docker.ezh.msk.ru:8000 '*' cmd.run "123"; echo $?
{
    "return": [
        {
            "ezh.msk.ru": {
                "jid": "20180414193904158892",
                "ret": "/bin/sh: 123: command not found",
                "retcode": 127
            },
            "saltstack.ezh.msk.ru": {
                "jid": "20180414193904158892",
                "ret": "/bin/sh: 1: 123: not found",
                "retcode": 127
            }
        }
    ]
}
```
**Exit code 127**

New options
---
```
> pepper -h
   ...
  retcode Field Validation Options:
    Validate return.HOST.retcode fields

    --fail-any          Fail if any of retcode field is non zero.
    --fail-any-none     Fail if any of retcode field is non zero or there is
                        no retcode at all.
    --fail-all          Fail if all retcode fields are non zero.
    --fail-all-none     Fail if all retcode fields are non zero or there is no
                        retcode at all.
```