### PR TITLE
default to nested

### DIFF
--- a/scripts/pepper
+++ b/scripts/pepper
@@ -61,7 +61,7 @@ class Pepper(object):
                                         # version >= 2017.7
                                         salt.output.display_output(
                                             {minionid: minionret['ret']},
-                                            self.cli.options.output or minionret.get('out', None) or self.output,
+                                            self.cli.options.output or minionret.get('out', None) or 'nested',
                                             opts=self.opts
                                         )
                                     else:


### PR DESCRIPTION
Don't need to use self.output if on >= 2017.7.  If out is not in the
full_return, then it isn't set on the module.