### PR TITLE
FIX FOR #154: Missing Attribute JSONDecodeError

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -18,6 +18,13 @@ except ImportError:
     from ConfigParser import ConfigParser, RawConfigParser
 
 try:
+    # Python 3
+    JSONDecodeError = json.decode.JSONDecodeError
+except AttributeError:
+    # Python 2
+    JSONDecodeError = ValueError
+
+try:
     input = raw_input
 except NameError:
     pass
@@ -470,7 +477,7 @@ class PepperCli(object):
                     key, value = arg.split('=', 1)
                     try:
                         low[key] = json.loads(value)
-                    except json.decoder.JSONDecodeError:
+                    except JSONDecodeError:
                         low[key] = value
                 else:
                     low.setdefault('args', []).append(arg)


### PR DESCRIPTION
Simple checking for AttributeError when getting
the Attributre json.decode.JSONDecodeError.
If Attribute does not exist we use ValueError.