### PR TITLE
Use json decode error everywhere

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -435,7 +435,7 @@ class PepperCli(object):
         if self.options.json_input:
             try:
                 return json.loads(self.options.json_input)
-            except ValueError:
+            except JSONDecodeError:
                 logger.error("Invalid JSON given.")
                 raise SystemExit(1)
 
@@ -444,7 +444,7 @@ class PepperCli(object):
                 with open(self.options.json_file, 'r') as json_content:
                     try:
                         return json.load(json_content)
-                    except ValueError:
+                    except JSONDecodeError:
                         logger.error("Invalid JSON given.")
                         raise SystemExit(1)
             except Exception as e:


### PR DESCRIPTION
This uses the JSONDecodeError abstraction for every json.loads call - this makes it more stringent.
