### PR TITLE
runner/wheel client uses 'arg' to specify args, not 'args'

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -513,7 +513,7 @@ class PepperCli(object):
                     except JSONDecodeError:
                         low[key] = value
                 else:
-                    low.setdefault('args', []).append(arg)
+                    low.setdefault('arg', []).append(arg)
         elif client.startswith('wheel'):
             low['fun'] = args.pop(0)
             for arg in args:
@@ -524,7 +524,7 @@ class PepperCli(object):
                     except JSONDecodeError:
                         low[key] = value
                 else:
-                    low.setdefault('args', []).append(arg)
+                    low.setdefault('arg', []).append(arg)
         elif client.startswith('ssh'):
             if len(args) < 2:
                 self.parser.error("Command or target not specified")

--- a/tests/integration/test_clients.py
+++ b/tests/integration/test_clients.py
@@ -21,7 +21,7 @@ def test_runner_client(pepper_cli):
         'one', 'two=what',
         'three={0}'.format(json.dumps({"hello": "world"})),
     )
-    assert ret == {"runner": {"args": [], "kwargs": {"args": ["one"], "three": {"hello": "world"}, "two": "what"}}}
+    assert ret == {"runner": {"args": ["one"], "kwargs": {"three": {"hello": "world"}, "two": "what"}}}
 
 
 def test_wheel_client_arg(pepper_cli, session_minion_id):


### PR DESCRIPTION
seems this was overlooked at some point. wheelclient only seems to take
a kwarg argument, which might even be an oversight on the netapi side..
I've left it if it is added in the future.