### PR TITLE
move kwarg parsing to api backend instead of in pepper

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -505,15 +505,10 @@ class PepperCli(object):
             low['arg'] = args
         elif client.startswith('runner'):
             low['fun'] = args.pop(0)
-            for arg in args:
-                if '=' in arg:
-                    key, value = arg.split('=', 1)
-                    try:
-                        low[key] = json.loads(value)
-                    except JSONDecodeError:
-                        low[key] = value
-                else:
-                    low.setdefault('arg', []).append(arg)
+            # kwargs are passed as is in foo=bar form, splitting and deserializing
+            # will happen in RunnerClient in the api; see https://github.com/saltstack/pepper/issues/57
+            # for further details
+            low['arg'] = args
         elif client.startswith('wheel'):
             low['fun'] = args.pop(0)
             for arg in args:


### PR DESCRIPTION
rather than attempting to deconstruct args locally to fully reproduce
the proper low state to pass to the api, we instead leave the kwargs as
is. The reason for this is the RunnerClient will deconstruct and
deserialize nested yaml args. We could equivalently do that locally but
it seems pepper tries to be a no-dependency dist so we just hand off the
work instead.

Fixes #57