### PR TITLE
Replace kerberos with spnego

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -411,7 +411,9 @@ class PepperCli(object):
         else:
             if self.options.username is not None:
                 results['SALTAPI_USER'] = self.options.username
-        if self.options.password is None and results['SALTAPI_PASS'] is None:
+        if self.options.password is None and \
+                results['SALTAPI_PASS'] is None and \
+                results['SALTAPI_EAUTH'] != 'kerberos':
             if self.options.interactive:
                 results['SALTAPI_PASS'] = getpass.getpass(prompt='Password: ')
             else:

--- a/pepper/libpepper.py
+++ b/pepper/libpepper.py
@@ -267,8 +267,8 @@ class Pepper(object):
 
         '''
         import requests
-        from requests_kerberos import HTTPKerberosAuth, OPTIONAL
-        auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+        from requests_gssapi import HTTPSPNEGOAuth, OPTIONAL
+        auth = HTTPSPNEGOAuth(mutual_authentication=OPTIONAL)
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ setup_kwargs = {
     'packages': [
         'pepper',
     ],
+    'extras_require': {
+        'kerberos': ["requests-gssapi>=1.1.0"],
+    },
     'scripts': [
         'scripts/pepper',
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,6 @@ def pepperconfig(salt_api_port):
         SALTAPI_EAUTH=sharedsecret
         [noopts]
         SALTAPI_URL=http://localhost:{0}/
-        SALTAPI_EAUTH=kerberos
     '''.format(salt_api_port))
     with open('tests/.pepperrc', 'w') as pepper_file:
         print(config, file=pepper_file)


### PR DESCRIPTION
Replace the aged and, according to one of the maintainers, deprecated and replaced (see https://github.com/requests/requests-kerberos/issues/116#issuecomment-412692003) requests-kerberos with requests-gssapi. They are feature compatible and requests-gssapi even feature a shim, which I decided not to use since it's marked as deprecated, so we would only have to change the import.

6127060 maybe should have been another PR but I decided to put it here. It disabled the password prompt, which is unnecessary, when using eauth=kerberos.