### PR TITLE
Add CLI options for highstate formatter modes

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -110,7 +110,7 @@ class PepperCli(object):
 
         self.parser.add_option(
             '--state-output', dest='state_output', default="full", type="choice",
-            choices = [ "full", "terse", "mixed", "changes", "filter" ],
+            choices = [ "full", "full_id", "terse", "terse_id", "mixed", "mixed_id", "changes", "changes_id", "filter", "filter_id" ],
             help=textwrap.dedent('''
                 Output mode for highstate formatter
             ''')

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -109,6 +109,21 @@ class PepperCli(object):
         )
 
         self.parser.add_option(
+            '--state-output', dest='state_output', default="full", type="choice",
+            choices = [ "full", "terse", "mixed", "changes", "filter" ],
+            help=textwrap.dedent('''
+                Output mode for highstate formatter
+            ''')
+        )
+
+        self.parser.add_option(
+            '--state-verbose', dest='state_verbose', default=None,
+            help=textwrap.dedent('''
+                Set to false to hide results with no changes
+            ''')
+        )
+
+        self.parser.add_option(
             '--output-file', dest='output_file', default=None,
             help=textwrap.dedent('''
                 File to put command output in

--- a/pepper/script.py
+++ b/pepper/script.py
@@ -36,6 +36,11 @@ class Pepper(object):
             self.opts = {}
         if self.cli.options.output_file is not None:
             self.opts['output_file'] = self.cli.options.output_file
+        if self.cli.options.state_output is not None:
+            self.opts['state_output'] = self.cli.options.state_output
+        if self.cli.options.state_verbose is not None:
+            self.opts['state_verbose'] = self.cli.options.state_verbose in [ "true", "True", "1" ]
+
 
     @property
     def output(self):


### PR DESCRIPTION
Support the --state-output and --state-verbose options for the highstate formatter. These allow selecting a more compact output format for states without changes or errors or hiding them entirely.
