### PR TITLE
Migrate Travis CI testing setup to GitHub actions

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,0 +1,23 @@
+name: flake8 lint
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-20.04
+    name: flake8 lint
+    steps:
+      - name: Setup python for flake8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - uses: actions/checkout@v3
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Setup flake8
+        run: tox -vv --notest -e flake8
+      - name: Run flake8
+        run: tox -vv -e flake8

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -2,8 +2,6 @@ name: flake8 lint
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 8 * * *"
 
 jobs:
   flake8-lint:

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -18,6 +18,6 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Setup flake8
-        run: tox -vv --notest -e flake8
+        run: tox --notest -e flake8
       - name: Run flake8
-        run: tox -vv -e flake8
+        run: tox -e flake8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,6 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Setup tests
-        run: tox -vv --notest -e py${{ matrix.py }}-${{ matrix.netapi }}-${{ matrix.salt }}
+        run: tox --notest -e py${{ matrix.py }}-${{ matrix.netapi }}-${{ matrix.salt }}
       - name: Run tests
-        run: tox -vv -e py${{ matrix.py }}-${{ matrix.netapi }}-${{ matrix.salt }}
+        run: tox -e py${{ matrix.py }}-${{ matrix.netapi }}-${{ matrix.salt }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,11 @@ jobs:
           - "v3004.2"
           - "v3005.1"
           - "master"
+        exclude:
+          - salt: master
+            py: "3.5"
+          - salt: master
+            py: "3.6"
     steps:
       - name: Setup python for test ${{ matrix.py }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,44 @@
+name: test
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  test:
+    name: test ${{ matrix.py }} - ${{ matrix.netapi }} - ${{ matrix.salt }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        py:
+          - "3.5"
+          - "3.6"
+          - "3.7"
+          - "3.8"
+        netapi:
+          - "cherrypy"
+          - "tornado"
+        salt:
+          - "v3004.2"
+          - "v3005.1"
+          - "master"
+    steps:
+      - name: Setup python for test ${{ matrix.py }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.py }}
+      - uses: actions/checkout@v3
+      - name: Install setuptools_scm
+        run: python -m pip install setuptools_scm
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y libc6-dev libffi-dev gcc git openssh-server libzmq3-dev
+        env:
+          DEBIAN_FRONTEND: noninteractive
+      - name: Setup tests
+        run: tox -vv --notest -e py${{ matrix.py }}-${{ matrix.netapi }}-${{ matrix.salt }}
+      - name: Run tests
+        run: tox -vv -e py${{ matrix.py }}-${{ matrix.netapi }}-${{ matrix.salt }}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,8 +3,9 @@ pytest>=3.5.0,<4.0.0
 pytest-rerunfailures
 pytest-cov
 git+https://github.com/vmware-archive/pytest-salt@master#egg=pytest-salt
-tornado<5.0.0
+tornado==6.1
 CherryPy
 setuptools_scm
-pyzmq>=2.2.0,<17.1.0; python_version == '3.4'  # pyzmq 17.1.0 stopped building wheels for python3.4
-pyzmq>=2.2.0; python_version != '3.4'
+pyzmq<=20.0.0 ; python_version < "3.6"
+pyzmq>=17.0.0 ; python_version < "3.9"
+pyzmq>19.0.2 ; python_version >= "3.9"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ mock
 pytest>=3.5.0,<4.0.0
 pytest-rerunfailures
 pytest-cov
-git+https://github.com/saltstack/pytest-salt@master#egg=pytest-salt
+git+https://github.com/vmware-archive/pytest-salt@master#egg=pytest-salt
 tornado<5.0.0
 CherryPy
 setuptools_scm

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = py{27,34,35,36,37,38}-{cherrypy,tornado}-{v2018.3,v2019.2,develop},coverage,flake8
+envlist = py{35,36,37,38}-{cherrypy,tornado}-{v3004.2,v3005.1,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 
 [testenv]
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV, CI, TRAVIS, TRAVIS_*, CODECOV_*
 deps = -r{toxinidir}/tests/requirements.txt
-    v2018.3: salt<2018.4
-    v2019.2: salt<2019.3
-    develop: git+https://github.com/saltstack/salt.git@develop#egg=salt
+    v3004.2: salt<3004.2
+    v3005.1: salt<3005.1
+    master: git+https://github.com/saltstack/salt.git@master#egg=salt
 
 changedir = {toxinidir}
 setenv = COVERAGE_FILE = {toxworkdir}/.coverage.{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands = flake8 tests/ pepper/ scripts/pepper setup.py
 [testenv:coverage]
 skip_install = True
 deps =
-    coverage >= 4.4.1, < 5
+    coverage >= 7.0.5, < 8
 setenv = COVERAGE_FILE={toxworkdir}/.coverage
 changedir = {toxinidir}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}-{cherrypy,tornado}-{v3004.2,v3005.1,master},coverage,flake8
+envlist = py{3.5,3.6,3.7,3.8}-{cherrypy,tornado}-{v3004.2,v3005.1,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 


### PR DESCRIPTION
Migrates tests to Github Actions as per issue https://github.com/saltstack/pepper/issues/220.

This does the minimum possible to get the tests running as GH Actions workflows against current Salt and Python versions. I've stuck with the existing tox setup and only updated requirements where necessary to get the tests to set up and run.

I haven't setup the codecov functionality but will tackle that at a later stage,

Currently, some tests are failing for almost all the combinations of python/salt/transport. The majority of those are the integration tests, which rely on the archived pytest-salt extension.

Think it would be worth merging this as is and I'll then work on issues with the actual test suite in https://github.com/saltstack/pepper/issues/225

