### PR TITLE
Update test suite to test against 3006.0 and python 3.9 and 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,15 @@ jobs:
         py:
           - "3.7"
           - "3.8"
+          - "3.9"
+          - "3.10"
         netapi:
           - "cherrypy"
           - "tornado"
         salt:
           - "v3004.2"
           - "v3005.1"
+          - "v3006.0"
           - "master"
     steps:
       - name: Setup python for test ${{ matrix.py }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,11 @@ jobs:
           - "v3005.1"
           - "v3006.0"
           - "master"
+        exclude:
+          - py: "3.10"
+            salt: "v3004.2"
+          - py: "3.10"
+            salt: "v3005.1"
     steps:
       - name: Setup python for test ${{ matrix.py }}
         uses: actions/setup-python@v4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,7 @@ pytest-cov
 pytest-salt-factories==0.912.2
 CherryPy
 setuptools_scm
+importlib-metadata<5.0.0
 pyzmq<=20.0.0 ; python_version < "3.6"
 pyzmq>=17.0.0 ; python_version < "3.9"
 pyzmq>19.0.2 ; python_version >= "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.7,3.8,3.9,3.10}-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0,master},coverage,flake8
+envlist = py{3.7,3.8,3.9}-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0,master},py{3.10}-{cherrypy,tornado}-{v3006.0,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.7,3.8}-{cherrypy,tornado}-{v3004.2,v3005.1,master},coverage,flake8
+envlist = py{3.7,3.8,3.9,3.10}-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 
@@ -9,7 +9,8 @@ deps = -r{toxinidir}/tests/requirements.txt
     v3004.2: salt<3004.2
     v3004.2: jinja2<3.1
     v3005.1: salt<3005.1
-    py3.7-{cherrypy,tornado}-{v3004.2,v3005.1}: importlib-metadata<5.0.0
+    v3006.0: salt<3006.0
+    py3.7-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0}: importlib-metadata<5.0.0
     master: git+https://github.com/saltstack/salt.git@master#egg=salt
 
 changedir = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ skipsdist = false
 [testenv]
 passenv = TOXENV, CI, TRAVIS, TRAVIS_*, CODECOV_*
 deps = -r{toxinidir}/tests/requirements.txt
-    v3004.2: salt<3004.2
+    v3004.2: salt==3004.2
     v3004.2: jinja2<3.1
-    v3005.1: salt<3005.1
-    v3006.0: salt<3006.0
+    v3005.1: salt==3005.1
+    v3006.0: salt==3006.0
     py3.7-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0}: importlib-metadata<5.0.0
     master: git+https://github.com/saltstack/salt.git@master#egg=salt
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps = -r{toxinidir}/tests/requirements.txt
     v3004.2: jinja2<3.1
     v3005.1: salt==3005.1
     v3006.0: salt==3006.0
-    py3.7-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0}: importlib-metadata<5.0.0
     master: git+https://github.com/saltstack/salt.git@master#egg=salt
 
 changedir = {toxinidir}


### PR DESCRIPTION
Updates the test suite to test against 3006.0 now that has been release.
Also adds testing using python 3.9 (for all salt versions) and 3.10 (for 3006.0 and master)