### PR TITLE
Add force color option for Salt outputters

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -109,6 +109,13 @@ class PepperCli(object):
         )
 
         self.parser.add_option(
+            '--output-force-color', dest='output_force_color', default=False, action='store_true',
+            help=textwrap.dedent('''
+                Force salt outputter to use color when printing.
+            ''')
+        )
+
+        self.parser.add_option(
             '--output-file', dest='output_file', default=None,
             help=textwrap.dedent('''
                 File to put command output in

--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -109,7 +109,7 @@ class PepperCli(object):
         )
 
         self.parser.add_option(
-            '--output-force-color', dest='output_force_color', default=False, action='store_true',
+            '--force-color', '--force-colour', dest='output_force_color', default=False, action='store_true',
             help=textwrap.dedent('''
                 Force salt outputter to use color when printing.
             ''')

--- a/pepper/script.py
+++ b/pepper/script.py
@@ -32,6 +32,8 @@ class Pepper(object):
         self.cli = PepperCli()
         if HAS_SALT:
             self.opts = salt.config.client_config(self.cli.options.master)
+            if self.cli.options.output_force_color:
+                self.opts['color'] = True
         else:
             self.opts = {}
         if self.cli.options.output_file is not None:


### PR DESCRIPTION
The salt CLI commands offer an option to force color output. An option on the Pepper CLI now offers the equivalent feature.