### PR TITLE
Make the dependency to setuptools explicit for python > 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ setup_kwargs = {
     'packages': [
         'pepper',
     ],
+    'install_requires'=[
+        'setuptools;python_version>="3.12"',
+    ],
     'extras_require': {
         'kerberos': ["requests-gssapi>=1.1.0"],
     },


### PR DESCRIPTION
``pkg_resources`` is imported and it's inside setuptools which breaks under python 3.12. 
```
File /venv/lib/python3.12/site-packages/example.py, line 5, in <module>
  import pepper
File /venv/lib/python3.12/site-packages/pepper/__init__.py, line 4, in <module>
  import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
There's an easy workaround (installing setuptools ourselves), but it would be nice to release a new version for this to be handled by pip.