### PR TITLE
Fix up python/salt versions to get tests working again

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   flake8-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: flake8 lint
     steps:
       - name: Setup python for flake8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,23 +13,22 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         netapi:
           - "cherrypy"
           - "tornado"
         salt:
-          - "v3004.2"
-          - "v3005.1"
-          - "v3006.0"
+          - "v3005.4"
+          - "v3006.4"
           - "master"
         exclude:
           - py: "3.10"
-            salt: "v3004.2"
-          - py: "3.10"
-            salt: "v3005.1"
+            salt: "v3005.4"
+          - py: "3.11"
+            salt: "v3005.4"
     steps:
       - name: Setup python for test ${{ matrix.py }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           - "tornado"
         salt:
           - "v3005.4"
-          - "v3006.4"
+          - "v3006.5"
           - "master"
         exclude:
           - py: "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: test ${{ matrix.py }} - ${{ matrix.netapi }} - ${{ matrix.salt }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: test ${{ matrix.py }} - ${{ matrix.netapi }} - ${{ matrix.salt }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,14 +21,18 @@ jobs:
           - "cherrypy"
           - "tornado"
         salt:
-          - "v3005.4"
-          - "v3006.5"
+          - "v3006.9"
+          - "v3007.1"
           - "master"
         exclude:
-          - py: "3.10"
-            salt: "v3005.4"
-          - py: "3.11"
-            salt: "v3005.4"
+          - py: "3.8"
+            salt: "v3007.1"
+          - py: "3.9"
+            salt: "v3007.1"
+          - py: "3.8"
+            salt: "master"
+          - py: "3.9"
+            salt: "master"
     steps:
       - name: Setup python for test ${{ matrix.py }}
         uses: actions/setup-python@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libraries
 import logging
@@ -9,18 +9,17 @@ import sys
 import tempfile
 import textwrap
 
-# Import Salt Libraries
-import salt.utils.yaml as yaml
-
 # Import pytest libraries
 import pytest
+
+# Import Salt Libraries
+import salt.utils.yaml as yaml
 from pytestskipmarkers.utils import ports
 from saltfactories.utils import random_string, running_username
 
 # Import Pepper libraries
 import pepper
 import pepper.script
-
 
 log = logging.getLogger(__name__)
 
@@ -238,6 +237,16 @@ def session_master_config_overrides(request, salt_api_port, salt_api_backend):
             'run'
         ]
     }
+
+
+@pytest.helpers.register
+def remove_stale_minion_key(master, minion_id):
+    """Helper to remove a stale minion key."""
+    key_path = os.path.join(master.config["pki_dir"], "minions", minion_id)
+    if os.path.exists(key_path):
+        os.unlink(key_path)
+    else:
+        log.debug("The minion(id=%r) key was not found at %s", minion_id, key_path)
 
 
 @pytest.fixture(scope='session')

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@ pytest-rerunfailures
 pytest-cov
 pytest-salt-factories==0.912.2
 CherryPy
-setuptools_scm
+setuptools_scm==7.1.0
 importlib-metadata<5.0.0
 pyzmq<=20.0.0 ; python_version < "3.6"
 pyzmq>=17.0.0 ; python_version < "3.9"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,10 +2,11 @@ mock
 pytest>=6.0.0
 pytest-rerunfailures
 pytest-cov
-pytest-salt-factories==0.912.2
+pytest-salt-factories==1.0.4
 CherryPy
 setuptools_scm==7.1.0
 importlib-metadata<5.0.0
-pyzmq<=20.0.0 ; python_version < "3.6"
-pyzmq>=17.0.0 ; python_version < "3.9"
-pyzmq>19.0.2 ; python_version >= "3.9"
+pyzmq>=25.1.2 ; python_version < '3.13'
+pyzmq>=26.2.0 ; python_version >= '3.13'
+cryptography>=42.0.0; python_version < '3.13'
+cryptography==42.0.2; python_version >= '3.13'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.8,3.9}-{cherrypy,tornado}-{v3005.4,master},py{3.10,3.11}-{cherrypy,tornado}-{v3006.4,master},coverage,flake8
+envlist = py{3.8,3.9}-{cherrypy,tornado}-{v3005.4,v3006.5,master},py{3.10,3.11}-{cherrypy,tornado}-{v3006.5,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 
@@ -7,7 +7,7 @@ skipsdist = false
 passenv = TOXENV, CI, TRAVIS, TRAVIS_*, CODECOV_*
 deps = -r{toxinidir}/tests/requirements.txt
     v3005.4: salt==3005.4
-    v3006.4: salt==3006.4
+    v3006.5: salt==3006.5
     master: git+https://github.com/saltstack/salt.git@master#egg=salt
 
 changedir = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
-envlist = py{3.7,3.8,3.9}-{cherrypy,tornado}-{v3004.2,v3005.1,v3006.0,master},py{3.10}-{cherrypy,tornado}-{v3006.0,master},coverage,flake8
+envlist = py{3.8,3.9}-{cherrypy,tornado}-{v3005.4,master},py{3.10,3.11}-{cherrypy,tornado}-{v3006.4,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 
 [testenv]
 passenv = TOXENV, CI, TRAVIS, TRAVIS_*, CODECOV_*
 deps = -r{toxinidir}/tests/requirements.txt
-    v3004.2: salt==3004.2
-    v3004.2: jinja2<3.1
-    v3005.1: salt==3005.1
-    v3006.0: salt==3006.0
+    v3005.4: salt==3005.4
+    v3006.4: salt==3006.4
     master: git+https://github.com/saltstack/salt.git@master#egg=salt
 
 changedir = {toxinidir}
@@ -45,7 +43,7 @@ commands = codecov --file "{toxworkdir}/coverage.xml"
 
 [testenv:http]
 skip_install = True
-basepython = python36
+basepython = python39
 deps =
 changedir = {toxinidir}/htmlcov
 commands = python -m http.server

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py{3.8,3.9}-{cherrypy,tornado}-{v3005.4,v3006.5,master},py{3.10,3.11}-{cherrypy,tornado}-{v3006.5,master},coverage,flake8
+envlist = py{3.8,3.9}-{cherrypy,tornado}-{v3006.9,v3007.1},py{3.10,3.11}-{cherrypy,tornado}-{v3006.9,v3007.1,master},coverage,flake8
 skip_missing_interpreters = true
 skipsdist = false
 
 [testenv]
 passenv = TOXENV, CI, TRAVIS, TRAVIS_*, CODECOV_*
 deps = -r{toxinidir}/tests/requirements.txt
-    v3005.4: salt==3005.4
-    v3006.5: salt==3006.5
+    v3006.9: salt==3006.9
+    v3007.1: salt==3007.1
     master: git+https://github.com/saltstack/salt.git@master#egg=salt
 
 changedir = {toxinidir}


### PR DESCRIPTION
Fixes up the combinations of salt and python versions so that tests will pass again

That's reduced the combination slightly, but I think it's reasonable to not try and test against really old python versions. This is now testing:

| Salt version | Python versions |
| ----------------- | ------------------------|
| master         | 3.10, 3.11             |
| 3007.1          | 3.10, 3.11             |
| 3006.9          | 3.10, 3.11             |




